### PR TITLE
[mpxpy] Update client interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mpxpy
 
-The official Python client for the Mathpix API. Process PDFs, images, and convert math/text content with the Mathpix API.
+The official Python client for the Mathpix API. Process PDFs and images, and convert math/text content with the Mathpix API.
 
 ## Installation
 
@@ -13,10 +13,12 @@ pip install mpxpy
 You'll need a Mathpix API app_id and app_key to use this client. You can get these from the [Mathpix Console](https://console.mathpix.com/).
 
 Set your credentials by either:
+
 - Using environment variables
 - Passing them directly when initializing the client
 
 MathpixClient will prioritize auth configs in the following order:
+
 1. Passed through arguments
 2. The `~/.mpx/config` file
 3. ENV vars located in `.env`
@@ -31,6 +33,8 @@ MATHPIX_APP_ID=your-app-id
 MATHPIX_APP_KEY=your-app-key
 MATHPIX_URL=https://api.mathpix.com  # optional, defaults to this value
 ```
+
+# Initialization
 
 ### Passing credentials directly
 
@@ -62,9 +66,9 @@ client = MathpixClient(
 )
 ```
 
-## Features
+# Process PDFs
 
-### Process a PDF
+## Basic Usage
 
 ```python
 from mpxpy.mathpix_client import MathpixClient
@@ -85,18 +89,57 @@ pdf = client.pdf_new(
 pdf.wait_until_complete(timeout=30)
 
 # Get the Markdown outputs
-md_output_path = pdf.save_md_file(path='output/sample.md')
-md_text = pdf.md() # is type str
+md_output_path = pdf.to_md_file(path='output/sample.md')
+md_text = pdf.to_md_text() # is type str
 print(md_text)
 # Get the DOCX outputs
-docx_output_path = pdf.save_docx_file(path='output/sample.docx')
-docx_bytes = pdf.docx() # is type bytes
+docx_output_path = pdf.to_docx_file(path='output/sample.docx')
+docx_bytes = pdf.to_docx_bytes() # is type bytes
 # Get the JSON outputs
-lines_json_output_path = pdf.save_lines_json(path='output/sample.lines.json')
-lines_json = pdf.lines_json() # is type Dict
+lines_json_output_path = pdf.to_lines_json_file(path='output/sample.lines.json')
+lines_json = pdf.to_lines_json() # parses JSON into type Dict
 ```
 
-### Process an Image
+## Pdf Class Documentation
+
+### Properties
+
+- `auth`: An Auth instance with Mathpix credentials.
+- `pdf_id`: The unique identifier for this PDF.
+- `file_path`: Path to a local PDF file.
+- `url`: URL of a remote PDF file.
+- `convert_to_docx`: Optional boolean to automatically convert your result to docx
+- `convert_to_md`: Optional boolean to automatically convert your result to md
+- `convert_to_mmd`: Optional boolean to automatically convert your result to mmd
+- `convert_to_tex_zip`: Optional boolean to automatically convert your result to tex.zip
+- `convert_to_html`: Optional boolean to automatically convert your result to html
+- `convert_to_pdf`: Optional boolean to automatically convert your result to pdf
+
+### Methods
+
+- `wait_until_complete`: Wait for the PDF processing and optional conversions to complete.
+- `pdf_status`: Get the current status of the PDF processing.
+- `pdf_conversion_status`: Get the current status of the PDF conversions.
+- `to_docx_file`: Save the processed PDF result to a DOCX file at a local path.
+- `to_docx_bytes`: Get the processed PDF result as DOCX bytes.
+- `to_md_file`: Save the processed PDF result to a Markdown file at a local path.
+- `to_md_text`: Get the processed PDF result as a Markdown string.
+- `to_mmd_file`: Save the processed PDF result to a Mathpix Markdown file at a local path.
+- `to_mmd_text`: Get the processed PDF result as a Mathpix Markdown string.
+- `to_tex_zip_file`: Save the processed PDF result to a tex.zip file at a local path.
+- `to_tex_zip_bytes`: Get the processed PDF result in tex.zip format as bytes.
+- `to_html_file`: Save the processed PDF result to a HTML file at a local path.
+- `to_html_bytes`: Get the processed PDF result in HTML format as bytes.
+- `to_pdf_file`: Save the processed PDF result to a PDF file at a local path.
+- `to_pdf_bytes`: Get the processed PDF result in PDF format as bytes.
+- `to_lines_json_file`: Save the processed PDF line-by-line result to a JSON file at a local path.
+- `to_lines_json`: Get the processed PDF result in JSON format.
+- `to_lines_mmd_json_file`: Save the processed PDF line-by-line result, including Mathpix Markdown, to a JSON file at a local path.
+- `to_lines_mmd_json`: Get the processed PDF result in JSON format with text in Mathpix Markdown.
+
+# Process Images
+
+## Basic Usage
 
 ```python
 from mpxpy.mathpix_client import MathpixClient
@@ -119,7 +162,22 @@ lines = image.lines_json()
 print(lines)
 ```
 
-### Convert Mathpix Markdown (MMD)
+## Image Class Documentation
+
+### Properties
+
+- `auth`: An Auth instance with Mathpix credentials.
+- `file_path`: Path to a local image file, if using a local file.
+- `url`: URL of a remote image, if using a remote file.
+
+### Methods
+
+- `lines_json`: Get line-by-line OCR data for the image.
+- `mmd`: Get the Mathpix Markdown (MMD) representation of the image.
+
+# Convert Mathpix Markdown (MMD)
+
+## Basic Usage
 
 ```python
 from mpxpy.mathpix_client import MathpixClient
@@ -140,16 +198,49 @@ conversion = client.conversion_new(
 conversion.wait_until_complete(timeout=30)
 
 # Get the Markdown outputs
-md_output_path = conversion.save_md_file(path='output/sample.md')
-md_text = conversion.md() # is of type str
+md_output_path = conversion.to_md_file(path='output/sample.md')
+md_text = conversion.to_md_text() # is of type str
 # Get the DOCX outputs
-docx_output_path = conversion.save_docx_file(path='output/sample.docx')
-docx_bytes = conversion.docx() # is of type bytes
+docx_output_path = conversion.to_docx_file(path='output/sample.docx')
+docx_bytes = conversion.to_docx_bytes() # is of type bytes
 ```
 
-## Error Handling
+## Conversion Class Documentation
+
+### Properties
+
+- `auth`: An Auth instance with Mathpix credentials.
+- `conversion_id`: The unique identifier for this conversion.
+- `convert_to_docx`: Optional boolean to automatically convert your result to docx
+- `convert_to_md`: Optional boolean to automatically convert your result to md
+- `convert_to_tex_zip`: Optional boolean to automatically convert your result to tex.zip
+- `convert_to_html`: Optional boolean to automatically convert your result to html
+- `convert_to_pdf`: Optional boolean to automatically convert your result to pdf
+- `convert_to_latex_pdf`: Optional boolean to automatically convert your result to pdf containing LaTeX
+
+### Methods
+
+- `wait_until_complete`: Wait for the conversion to complete.
+- `conversion_status`: Get the current status of the conversion.
+- `to_docx_file`: Save the processed conversion result to a DOCX file at a local path.
+- `to_docx_bytes`: Get the processed conversion result as DOCX bytes.
+- `to_md_file`: Save the processed conversion result to a Markdown file at a local path.
+- `to_md_text`: Get the processed conversion result as a Markdown string.
+- `to_mmd_file`: Save the processed conversion result to a Mathpix Markdown file at a local path.
+- `to_mmd_text`: Get the processed conversion result as a Mathpix Markdown string.
+- `to_tex_zip_file`: Save the processed conversion result to a tex.zip file at a local path.
+- `to_tex_zip_bytes`: Get the processed conversion result in tex.zip format as bytes.
+- `to_html_file`: Save the processed conversion result to a HTML file at a local path.
+- `to_html_bytes`: Get the processed conversion result in HTML format as bytes.
+- `to_pdf_file`: Save the processed conversion result to a PDF file at a local path.
+- `to_pdf_bytes`: Get the processed conversion result in PDF format as bytes.
+- `to_latex_pdf_file`: Save the processed conversion result to a PDF file containing LaTeX at a local path.
+- `to_latex_pdf_bytes`: Get the processed conversion result in PDF format as bytes (with LaTeX).
+
+# Error Handling
 
 The client provides detailed error information in the following classes:
+
 - MathpixClientError
 - AuthenticationError
 - ValidationError
@@ -169,14 +260,14 @@ except FileNotFoundError as e:
 except MathpixClientError as e:
     print(f"File upload error: {e}")
 try:
-    pdf.save_docx_file('output/path/example.pdf')
+    pdf.to_docx_file('output/path/example.pdf')
 except ConversionIncompleteError as e:
     print(f'Conversions are not complete')
 ```
 
-## Development
+# Development
 
-### Setup
+## Setup
 
 ```bash
 # Clone the repository
@@ -187,7 +278,7 @@ cd mpxpy
 pip install -e .
 ```
 
-### Running Tests
+## Running Tests
 
 ```bash
 # Install test dependencies

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 The official Python client for the Mathpix API. Process PDFs and images, and convert math/text content with the Mathpix API.
 
+# Setup
+
 ## Installation
 
 ```bash
@@ -10,7 +12,7 @@ pip install mpxpy
 
 ## Authentication
 
-You'll need a Mathpix API app_id and app_key to use this client. You can get these from the [Mathpix Console](https://console.mathpix.com/).
+You'll need a Mathpix API app_id and app_key to use this client. You can get these from [Mathpix Console](https://console.mathpix.com/).
 
 Set your credentials by either:
 
@@ -24,6 +26,8 @@ MathpixClient will prioritize auth configs in the following order:
 3. ENV vars located in `.env`
 4. ENV vars located in `local.env`
 
+## Initialization
+
 ### Using environment variables
 
 Create a config file at `~/.mpx/config` or add ENV variables to `.env` or `local.env` files:
@@ -32,19 +36,6 @@ Create a config file at `~/.mpx/config` or add ENV variables to `.env` or `local
 MATHPIX_APP_ID=your-app-id
 MATHPIX_APP_KEY=your-app-key
 MATHPIX_URL=https://api.mathpix.com  # optional, defaults to this value
-```
-
-# Initialization
-
-### Passing credentials directly
-
-```python
-from mpxpy.mathpix_client import MathpixClient
-
-client = MathpixClient(
-    app_id="your-app-id",
-    app_key="your-app-key"
-)
 ```
 
 Then initialize the client:
@@ -56,13 +47,17 @@ from mpxpy.mathpix_client import MathpixClient
 client = MathpixClient()
 ```
 
+### Using arguments
+
+You can also pass in your App ID and App Key when initializing the client:
+
 ```python
 from mpxpy.mathpix_client import MathpixClient
 
-# Will use passed arguments
 client = MathpixClient(
     app_id="your-app-id",
     app_key="your-app-key"
+    # Optional "api_url" argument sets the base URL. This can be useful for development with on-premise deployments
 )
 ```
 
@@ -78,7 +73,7 @@ client = MathpixClient(
     app_key="your-app-key"
 )
 
-# Process a PDF file
+# Process a PDF file with multiple conversion formats and options
 pdf = client.pdf_new(
     url="http://cs229.stanford.edu/notes2020spring/cs229-notes1.pdf",
     convert_to_docx=True,
@@ -187,7 +182,7 @@ client = MathpixClient(
     app_key="your-app-key"
 )
 
-# Convert Mathpix Markdown to various formats
+# Similar to Pdf, Conversion class takes separate arguments for each conversion format
 conversion = client.conversion_new(
     mmd="\\frac{1}{2}",
     convert_to_docx=True,

--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ from mpxpy.mathpix_client import MathpixClient
 
 # Will use ~/.mpx/config or environment variables
 client = MathpixClient()
+```
+
+```python
+from mpxpy.mathpix_client import MathpixClient
 
 # Will use passed arguments
 client = MathpixClient(
@@ -71,20 +75,25 @@ client = MathpixClient(
 )
 
 # Process a PDF file
-pdf_file = client.pdf_new(
-    file_url="http://cs229.stanford.edu/notes2020spring/cs229-notes1.pdf",
-    conversion_formats={
-        "docx": True,
-        "md": True
-    }
+pdf = client.pdf_new(
+    url="http://cs229.stanford.edu/notes2020spring/cs229-notes1.pdf",
+    convert_to_docx=True,
+    convert_to_md=True,
 )
 
-# Wait for processing to complete
-pdf_file.wait_until_complete(timeout=60)
+# Wait for processing to complete. Optional timeout argument is 60 seconds by default.
+pdf.wait_until_complete(timeout=30)
 
-# Download the converted files
-docx_output_path = pdf_file.download_output_to_local_path(conversion_format="docx", output_folder="./output", output_name='cd229-notes1.docx')
-md_output_path = pdf_file.download_output_to_local_path(conversion_format="md", output_folder="./output", output_name='cd229-notes1.docx')
+# Get the Markdown outputs
+md_output_path = pdf.save_md_file(path='output/sample.md')
+md_text = pdf.md() # is type str
+print(md_text)
+# Get the DOCX outputs
+docx_output_path = pdf.save_docx_file(path='output/sample.docx')
+docx_bytes = pdf.docx() # is type bytes
+# Get the JSON outputs
+lines_json_output_path = pdf.save_lines_json(path='output/sample.lines.json')
+lines_json = pdf.lines_json() # is type Dict
 ```
 
 ### Process an Image
@@ -98,7 +107,7 @@ client = MathpixClient(
 )
 # Process an image file
 image = client.image_new(
-    file_url="https://mathpix-ocr-examples.s3.amazonaws.com/cases_hw.jpg"
+    url="https://mathpix-ocr-examples.s3.amazonaws.com/cases_hw.jpg"
 )
 
 # Get the Mathpix Markdown (MMD) representation
@@ -119,17 +128,23 @@ client = MathpixClient(
     app_id="your-app-id",
     app_key="your-app-key"
 )
+
 # Convert Mathpix Markdown to various formats
 conversion = client.conversion_new(
     mmd="\\frac{1}{2}",
-    conversion_formats={"docx": True}
+    convert_to_docx=True,
+    convert_to_md=True,
 )
 
 # Wait for conversion to complete
 conversion.wait_until_complete(timeout=30)
 
-# Download the converted output
-output_path = conversion.download_output_to_local_path(conversion_format="docx", output_folder="./output", output_name='math-conversion.docx')
+# Get the Markdown outputs
+md_output_path = conversion.save_md_file(path='output/sample.md')
+md_text = conversion.md() # is of type str
+# Get the DOCX outputs
+docx_output_path = conversion.save_docx_file(path='output/sample.docx')
+docx_bytes = conversion.docx() # is of type bytes
 ```
 
 ## Error Handling
@@ -148,13 +163,13 @@ from mpxpy.errors import MathpixClientError, ConversionIncompleteError
 client = MathpixClient(app_id="your-app-id", app_key="your-app-key")
 
 try:
-    pdf = client.pdf_new(file_path="example.pdf", conversion_formats={'docx': True})
+    pdf = client.pdf_new(file_path="example.pdf", convert_to_docx=True)
 except FileNotFoundError as e:
     print(f"File not found: {e}")
 except MathpixClientError as e:
     print(f"File upload error: {e}")
 try:
-    pdf.download_output_to_local_path('docx', 'output/path')
+    pdf.save_docx_file('output/path/example.pdf')
 except ConversionIncompleteError as e:
     print(f'Conversions are not complete')
 ```

--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ pdf_file = client.pdf_new(
 pdf_file.wait_until_complete(timeout=60)
 
 # Download the converted files
-pdf_file.download_output_to_local_path("docx", "./output")
-pdf_file.download_output_to_local_path("md", "./output")
+docx_output_path = pdf_file.download_output_to_local_path(conversion_format="docx", output_folder="./output", output_name='cd229-notes1.docx')
+md_output_path = pdf_file.download_output_to_local_path(conversion_format="md", output_folder="./output", output_name='cd229-notes1.docx')
 ```
 
 ### Process an Image
@@ -129,7 +129,7 @@ conversion = client.conversion_new(
 conversion.wait_until_complete(timeout=30)
 
 # Download the converted output
-docx_output = conversion.download_output("docx")
+output_path = conversion.download_output_to_local_path(conversion_format="docx", output_folder="./output", output_name='math-conversion.docx')
 ```
 
 ## Error Handling

--- a/mpxpy/auth.py
+++ b/mpxpy/auth.py
@@ -67,10 +67,12 @@ class Auth:
         Returns:
             bool: True if any config file was successfully loaded, False otherwise
         """
+        base_dir = os.path.dirname(os.path.abspath(__file__))  # Gets the directory of the current file (auth.py)
+        root_dir = os.path.dirname(base_dir)
         config_locations = [
             pathlib.Path.home() / ".mpx" / "config",  # ~/.mpx/config
-            pathlib.Path(".env"),
-            pathlib.Path("local.env"),
+            pathlib.Path(root_dir) / ".env",
+            pathlib.Path(root_dir) / "local.env",
         ]
         for config_path in config_locations:
             if config_path.exists():

--- a/mpxpy/conversion.py
+++ b/mpxpy/conversion.py
@@ -121,6 +121,9 @@ class Conversion:
         Raises:
             ConversionIncompleteError: If the conversion is not complete
         """
+        if path.endswith('/') or path.endswith('\\'):
+            filename = f"{self.conversion_id}.{conversion_format}"
+            path = os.path.join(path, filename)
         logger.info(f"Downloading output for Conversion {self.conversion_id} in format {conversion_format} to path {path}")
         endpoint = urljoin(self.auth.api_url, f'v3/converter/{self.conversion_id}.{conversion_format}')
         response = get(endpoint, headers=self.auth.headers)

--- a/mpxpy/conversion.py
+++ b/mpxpy/conversion.py
@@ -180,7 +180,7 @@ class Conversion:
             raise ConversionIncompleteError("Conversion not complete")
         return response.content
 
-    def save_docx_file(self, path: str) -> str:
+    def to_docx_file(self, path: str) -> str:
         """Save the processed conversion result to a DOCX file at a local path.
 
         Args:
@@ -194,7 +194,7 @@ class Conversion:
         """
         return self.save_file(path=path, conversion_format='docx')
 
-    def docx(self) -> bytes:
+    def to_docx_bytes(self) -> bytes:
         """Get the processed conversion result as DOCX bytes.
 
         Returns:
@@ -205,7 +205,7 @@ class Conversion:
         """
         return self.bytes_result(conversion_format='docx')
 
-    def save_md_file(self, path: str) -> str:
+    def to_md_file(self, path: str) -> str:
         """Save the processed conversion result to a Markdown file at a local path.
 
         Args:
@@ -219,7 +219,7 @@ class Conversion:
         """
         return self.save_file(path=path, conversion_format='md')
 
-    def md(self) -> str:
+    def to_md_text(self) -> str:
         """Get the processed conversion result as a Markdown string.
 
         Returns:
@@ -230,7 +230,7 @@ class Conversion:
         """
         return self.text_result(conversion_format='md')
 
-    def save_mmd_file(self, path: str) -> str:
+    def to_mmd_file(self, path: str) -> str:
         """Save the processed conversion result to a Mathpix Markdown file at a local path.
 
         Args:
@@ -244,7 +244,7 @@ class Conversion:
         """
         return self.save_file(path=path, conversion_format='mmd')
 
-    def mmd(self) -> str:
+    def to_mmd_text(self) -> str:
         """Get the processed conversion result as a Mathpix Markdown string.
 
         Returns:
@@ -255,7 +255,7 @@ class Conversion:
         """
         return self.text_result(conversion_format='mmd')
 
-    def save_tex_zip(self, path: str) -> str:
+    def to_tex_zip_file(self, path: str) -> str:
         """Save the processed conversion result to a tex.zip file at a local path.
 
         Args:
@@ -269,7 +269,7 @@ class Conversion:
         """
         return self.save_file(path=path, conversion_format='tex.zip')
 
-    def tex_zip(self) -> bytes:
+    def to_tex_zip_bytes(self) -> bytes:
         """Get the processed conversion result in tex.zip format as bytes.
 
         Returns:
@@ -280,7 +280,7 @@ class Conversion:
         """
         return self.bytes_result(conversion_format='tex.zip')
 
-    def save_html(self, path: str) -> str:
+    def to_html_file(self, path: str) -> str:
         """Save the processed conversion result to a HTML file at a local path.
 
         Args:
@@ -294,7 +294,7 @@ class Conversion:
         """
         return self.save_file(path=path, conversion_format='html')
 
-    def html(self) -> bytes:
+    def to_html_bytes(self) -> bytes:
         """Get the processed conversion result in HTML format as bytes.
 
         Returns:
@@ -305,7 +305,7 @@ class Conversion:
         """
         return self.bytes_result(conversion_format='html')
 
-    def save_pdf(self, path: str) -> str:
+    def to_pdf_file(self, path: str) -> str:
         """Save the processed conversion result to a PDF file at a local path.
 
         Args:
@@ -319,7 +319,7 @@ class Conversion:
         """
         return self.save_file(path=path, conversion_format='pdf')
 
-    def pdf(self) -> bytes:
+    def to_pdf_bytes(self) -> bytes:
         """Get the processed conversion result in PDF format as bytes.
 
         Returns:
@@ -330,7 +330,7 @@ class Conversion:
         """
         return self.bytes_result(conversion_format='pdf')
 
-    def save_latex_pdf(self, path: str) -> str:
+    def to_latex_pdf_file(self, path: str) -> str:
         """Save the processed conversion result to a PDF file containing LaTeX at a local path.
 
         Args:
@@ -344,7 +344,7 @@ class Conversion:
         """
         return self.save_file(path=path, conversion_format='latex.pdf')
 
-    def latex_pdf(self) -> bytes:
+    def to_latex_pdf_bytes(self) -> bytes:
         """Get the processed conversion result in PDF format as bytes (with LaTeX).
 
         Returns:

--- a/mpxpy/conversion.py
+++ b/mpxpy/conversion.py
@@ -115,12 +115,13 @@ class Conversion:
                 )
         return response.content
 
-    def download_output_to_local_path(self, conversion_format: Optional[str] = "pdf", path: Optional[str] = ""):
+    def download_output_to_local_path(self, conversion_format: Optional[str] = "pdf", output_folder: Optional[str] = "", output_name: Optional[str] = ""):
         """Download the conversion result and save it to a local file.
 
         Args:
             conversion_format: Output format extension (e.g., 'docx', 'pdf', 'latex.pdf').
-            path: Directory path where the file should be saved. Will be created if it doesn't exist.
+            output_folder: Directory path where the file should be saved. Will be created if it doesn't exist.
+            output_name: File name for the output. Default is {conversion_id}.{conversion_format}
 
         Returns:
             str: The path to the saved file.
@@ -129,14 +130,18 @@ class Conversion:
             ConversionIncompleteError: If the conversion is not complete
             FilesystemError: If output fails to save to the local path
         """
-        logger.info(f"Downloading conversion {self.conversion_id} in format {conversion_format} to path {path}")
+        if output_name == "":
+            output_name = f'{self.conversion_id}.{conversion_format}'
+        if output_folder != "" and output_folder[-1] != '/':
+            output_folder += '/'
+        logger.info(f"Downloading conversion {self.conversion_id} in format {conversion_format} to path {output_folder}{output_name}")
         endpoint = urljoin(self.auth.api_url, f'v3/converter/{self.conversion_id}.{conversion_format}')
         response = get(endpoint, headers=self.auth.headers)
         if response.status_code == 404:
             raise ConversionIncompleteError("Conversion not complete")
-        if path != "":
-            os.makedirs(path, exist_ok=True)
-        file_path = urljoin(path, f'{self.conversion_id}.{conversion_format}')
+        if output_folder != "":
+            os.makedirs(output_folder, exist_ok=True)
+        file_path = urljoin(output_folder, output_name)
         try:
             with open(file_path, 'wb') as f:
                 for chunk in response.iter_content(chunk_size=8192):

--- a/mpxpy/image.py
+++ b/mpxpy/image.py
@@ -114,5 +114,4 @@ class Image:
         """
         logger.info("Getting Mathpix Markdown (MMD) representation")
         result = self.results()
-        logger.info(result)
         return result['text']

--- a/mpxpy/image.py
+++ b/mpxpy/image.py
@@ -114,4 +114,5 @@ class Image:
         """
         logger.info("Getting Mathpix Markdown (MMD) representation")
         result = self.results()
+        logger.info(result)
         return result['text']

--- a/mpxpy/image.py
+++ b/mpxpy/image.py
@@ -1,6 +1,5 @@
 import json
 from pathlib import Path
-import os
 import requests
 from typing import Optional
 from urllib.parse import urljoin
@@ -17,31 +16,31 @@ class Image:
     Attributes:
         auth: An Auth instance with Mathpix credentials.
         file_path: Path to a local image file, if using a local file.
-        file_url: URL of a remote image, if using a remote file.
+        url: URL of a remote image, if using a remote file.
     """
-    def __init__(self, auth: Auth, file_path: Optional[str] = None, file_url: Optional[str] = None):
+    def __init__(self, auth: Auth, file_path: Optional[str] = None, url: Optional[str] = None):
         """Initialize an Image instance.
 
         Args:
             auth: Auth instance containing Mathpix API credentials.
             file_path: Path to a local image file.
-            file_url: URL of a remote image.
+            url: URL of a remote image.
 
         Raises:
             AuthenticationError: If auth is not provided
-            ValidationError: If neither file_path nor file_url is provided,
-                        or if both file_path and file_url are provided.
+            ValidationError: If neither file_path nor url is provided,
+                        or if both file_path and url are provided.
         """
         self.auth = auth
         if not self.auth:
             logger.error("Image requires an authenticated client")
             raise AuthenticationError("Image requires an authenticated client")
         self.file_path = file_path or ''
-        self.file_url = file_url or ''
-        if not self.file_path and not self.file_url:
+        self.url = url or ''
+        if not self.file_path and not self.url:
             logger.error("Image requires a file path or file URL")
             raise ValidationError("Image requires a file path or file URL")
-        if self.file_path and self.file_url:
+        if self.file_path and self.url:
             logger.error("Exactly one of file path or file URL must be provider")
             raise ValidationError("Exactly one of file path or file URL must be provider")
 
@@ -63,7 +62,7 @@ class Image:
             FileNotFoundError: If the file_path does not point to an existing file.
             ValueError: If the API request fails.
         """
-        logger.info(f"Processing image: path={self.file_path}, url={self.file_url}, include_line_data={include_line_data}")
+        logger.info(f"Processing image: path={self.file_path}, url={self.url}, include_line_data={include_line_data}")
         endpoint = urljoin(self.auth.api_url, 'v3/text')
         options = {
             "include_line_data": include_line_data
@@ -87,7 +86,7 @@ class Image:
                     logger.error(f"Mathpix image request failed: {e}")
                     raise ValueError(f"Mathpix image request failed: {e}")
         else:
-            options["src"] = self.file_url
+            options["src"] = self.url
             try:
                 response = requests.post(endpoint, json=options, headers=self.auth.headers)
                 response.raise_for_status()

--- a/mpxpy/pdf.py
+++ b/mpxpy/pdf.py
@@ -182,6 +182,9 @@ class Pdf:
         Raises:
             ConversionIncompleteError: If the conversion is not complete
         """
+        if path.endswith('/') or path.endswith('\\'):
+            filename = f"{self.pdf_id}.{conversion_format}"
+            path = os.path.join(path, filename)
         logger.info(f"Downloading output for PDF {self.pdf_id} in format {conversion_format} to path {path}")
         endpoint = urljoin(self.auth.api_url, f'v3/pdf/{self.pdf_id}.{conversion_format}')
         response = get(endpoint, headers=self.auth.headers)

--- a/mpxpy/pdf.py
+++ b/mpxpy/pdf.py
@@ -260,7 +260,7 @@ class Pdf:
             raise ConversionIncompleteError("Conversion not complete")
         return response.content
 
-    def save_docx_file(self, path: str) -> str:
+    def to_docx_file(self, path: str) -> str:
         """Save the processed PDF result to a DOCX file at a local path.
 
         Args:
@@ -274,7 +274,7 @@ class Pdf:
         """
         return self.save_file(path=path, conversion_format='docx')
 
-    def docx(self) -> bytes:
+    def to_docx_bytes(self) -> bytes:
         """Get the processed PDF result as DOCX bytes.
 
         Returns:
@@ -285,7 +285,7 @@ class Pdf:
         """
         return self.bytes_result(conversion_format='docx')
 
-    def save_md_file(self, path: str) -> str:
+    def to_md_file(self, path: str) -> str:
         """Save the processed PDF result to a Markdown file at a local path.
 
         Args:
@@ -299,7 +299,7 @@ class Pdf:
         """
         return self.save_file(path=path, conversion_format='md')
 
-    def md(self) -> str:
+    def to_md_text(self) -> str:
         """Get the processed PDF result as a Markdown string.
 
         Returns:
@@ -310,7 +310,7 @@ class Pdf:
         """
         return self.text_result(conversion_format='md')
 
-    def save_mmd_file(self, path: str) -> str:
+    def to_mmd_file(self, path: str) -> str:
         """Save the processed PDF result to a Mathpix Markdown file at a local path.
 
         Args:
@@ -324,7 +324,7 @@ class Pdf:
         """
         return self.save_file(path=path, conversion_format='mmd')
 
-    def mmd(self) -> str:
+    def to_mmd_text(self) -> str:
         """Get the processed PDF result as a Mathpix Markdown string.
 
         Returns:
@@ -335,7 +335,7 @@ class Pdf:
         """
         return self.text_result(conversion_format='mmd')
 
-    def save_tex_zip(self, path: str) -> str:
+    def to_tex_zip_file(self, path: str) -> str:
         """Save the processed PDF result to a tex.zip file at a local path.
 
         Args:
@@ -349,7 +349,7 @@ class Pdf:
         """
         return self.save_file(path=path, conversion_format='tex.zip')
 
-    def tex_zip(self) -> bytes:
+    def to_tex_zip_bytes(self) -> bytes:
         """Get the processed PDF result in tex.zip format as bytes.
 
         Returns:
@@ -360,7 +360,7 @@ class Pdf:
         """
         return self.bytes_result(conversion_format='tex.zip')
 
-    def save_html(self, path: str) -> str:
+    def to_html_file(self, path: str) -> str:
         """Save the processed PDF result to a HTML file at a local path.
 
         Args:
@@ -374,7 +374,7 @@ class Pdf:
         """
         return self.save_file(path=path, conversion_format='html')
 
-    def html(self) -> bytes:
+    def to_html_bytes(self) -> bytes:
         """Get the processed PDF result in HTML format as bytes.
 
         Returns:
@@ -385,7 +385,7 @@ class Pdf:
         """
         return self.bytes_result(conversion_format='html')
 
-    def save_pdf(self, path: str) -> str:
+    def to_pdf_file(self, path: str) -> str:
         """Save the processed PDF result to a PDF file at a local path.
 
         Args:
@@ -399,7 +399,7 @@ class Pdf:
         """
         return self.save_file(path=path, conversion_format='pdf')
 
-    def pdf(self) -> bytes:
+    def to_pdf_bytes(self) -> bytes:
         """Get the processed PDF result in PDF format as bytes.
 
         Returns:
@@ -410,7 +410,7 @@ class Pdf:
         """
         return self.bytes_result(conversion_format='pdf')
 
-    def save_lines_json(self, path: str) -> str:
+    def to_lines_json_file(self, path: str) -> str:
         """Save the processed PDF line-by-line result to a JSON file at a local path.
 
         Args:
@@ -424,7 +424,7 @@ class Pdf:
         """
         return self.save_file(path=path, conversion_format='lines.json')
 
-    def lines_json(self) -> Dict:
+    def to_lines_json(self) -> Dict:
         """Get the processed PDF result in JSON format.
 
         Returns:
@@ -435,7 +435,7 @@ class Pdf:
         """
         return self.json_result(conversion_format='lines.json')
 
-    def save_lines_mmd_json(self, path: str) -> str:
+    def to_lines_mmd_json_file(self, path: str) -> str:
         """Save the processed PDF line-by-line result, including Mathpix Markdown, to a JSON file at a local path.
 
         Args:
@@ -449,7 +449,7 @@ class Pdf:
         """
         return self.save_file(path=path, conversion_format='lines.mmd.json')
 
-    def lines_mmd_json(self) -> Dict:
+    def to_lines_mmd_json(self) -> Dict:
         """Get the processed PDF result in JSON format with text in Mathpix Markdown.
 
         Returns:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mpxpy"
-version = "0.0.6"
+version = "0.0.7"
 description = "Official Mathpix client for Python"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -11,71 +11,68 @@ current_dir = os.path.dirname(os.path.abspath(__file__))
 def client():
     return MathpixClient()
 
-
-def test_convert_mmd(client):
+def test_no_format_conversion(client):
     mmd = '''
     \( f(x)=\left\{\begin{array}{ll}x^{2} & \text { if } x<0 \\ 2 x & \text { if } x \geq 0\end{array}\right. \)
     '''
-    conversion = client.conversion_new(mmd=mmd, conversion_formats={'docx': True})
+    with pytest.raises(ValidationError):
+        client.conversion_new(mmd=mmd)
+
+def test_conversion(client):
+    mmd = '''
+    \( f(x)=\left\{\begin{array}{ll}x^{2} & \text { if } x<0 \\ 2 x & \text { if } x \geq 0\end{array}\right. \)
+    '''
+    conversion = client.conversion_new(mmd=mmd, convert_to_docx=True)
     assert conversion.conversion_id is not None
     conversion.wait_until_complete(timeout=10)
     status = conversion.conversion_status()
     assert status['status'] == 'completed'
 
-def test_convert_mmd_download(client):
+def test_conversion_get_result_docx(client):
     mmd = '''
     \( f(x)=\left\{\begin{array}{ll}x^{2} & \text { if } x<0 \\ 2 x & \text { if } x \geq 0\end{array}\right. \)
     '''
-    conversion = client.conversion_new(mmd=mmd, conversion_formats={'docx': True})
+    conversion = client.conversion_new(mmd=mmd, convert_to_docx=True)
     assert conversion.conversion_id is not None
     conversion.wait_until_complete(timeout=10)
-    content = conversion.download_output('docx')
-    assert content is not None
-    assert len(content) > 0
-    assert content.startswith(b'PK') # Test whether it matches the DOCX file signature
+    docx_bytes = conversion.docx()
+    assert docx_bytes is not None
+    assert len(docx_bytes) > 0
+    assert docx_bytes.startswith(b'PK') # Test whether it matches the DOCX file signature
 
-def test_convert_mmd_download_to_local(client):
+def test_conversion_save_docx_to_local_path(client):
     mmd = '''
     \( f(x)=\left\{\begin{array}{ll}x^{2} & \text { if } x<0 \\ 2 x & \text { if } x \geq 0\end{array}\right. \)
     '''
-    conversion = client.conversion_new(mmd=mmd, conversion_formats={'docx': True})
+    conversion = client.conversion_new(mmd=mmd, convert_to_docx=True)
     assert conversion.conversion_id is not None
-    output_dir = conversion.conversion_id
+    output_dir = 'output'
+    output_name = 'result.docx'
+    output_path = os.path.join(output_dir, output_name)
     try:
         conversion.wait_until_complete(timeout=10)
-        path = conversion.download_output_to_local_path('docx', path=output_dir)
+        path = conversion.save_docx_file(path=output_path)
         assert os.path.exists(path)
         assert os.path.getsize(path) > 0
     finally:
         if os.path.exists(output_dir) and os.path.isdir(output_dir):
             shutil.rmtree(output_dir)
 
-
-def test_convert_mmd_bad_conversion_format(client):
+def test_conversion_bad_timeout(client):
     mmd = '''
     \( f(x)=\left\{\begin{array}{ll}x^{2} & \text { if } x<0 \\ 2 x & \text { if } x \geq 0\end{array}\right. \)
     '''
-    with pytest.raises(MathpixClientError):
-        client.conversion_new(mmd=mmd, conversion_formats={'latex': True})
-
-def test_convert_mmd_bad_timeout(client):
-    mmd = '''
-    \( f(x)=\left\{\begin{array}{ll}x^{2} & \text { if } x<0 \\ 2 x & \text { if } x \geq 0\end{array}\right. \)
-    '''
-    conversion = client.conversion_new(mmd=mmd, conversion_formats={'docx': True})
+    conversion = client.conversion_new(mmd=mmd, convert_to_docx=True)
     with pytest.raises(ValidationError):
         conversion.wait_until_complete(timeout=0)
 
-def test_convert_mmd_incomplete_conversion(client):
+def test_conversion_incomplete_conversion(client):
     mmd = '''
     \( f(x)=\left\{\begin{array}{ll}x^{2} & \text { if } x<0 \\ 2 x & \text { if } x \geq 0\end{array}\right. \)
     '''
-    conversion = client.conversion_new(mmd=mmd, conversion_formats={'docx': True})
+    conversion = client.conversion_new(mmd=mmd, convert_to_docx=True)
     with pytest.raises(ConversionIncompleteError):
-        conversion.download_output(conversion_format='docx')
+        conversion.docx()
 
 if __name__ == '__main__':
     client = MathpixClient()
-    # test_convert_mmd(client)
-    # test_convert_mmd_download(client)
-    # test_convert_mmd_download_to_local(client)

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -35,7 +35,7 @@ def test_conversion_get_result_docx(client):
     conversion = client.conversion_new(mmd=mmd, convert_to_docx=True)
     assert conversion.conversion_id is not None
     conversion.wait_until_complete(timeout=10)
-    docx_bytes = conversion.docx()
+    docx_bytes = conversion.to_docx_bytes()
     assert docx_bytes is not None
     assert len(docx_bytes) > 0
     assert docx_bytes.startswith(b'PK') # Test whether it matches the DOCX file signature
@@ -51,7 +51,7 @@ def test_conversion_save_docx_to_local_path(client):
     output_path = os.path.join(output_dir, output_name)
     try:
         conversion.wait_until_complete(timeout=10)
-        path = conversion.save_docx_file(path=output_path)
+        path = conversion.to_docx_file(path=output_path)
         assert os.path.exists(path)
         assert os.path.getsize(path) > 0
     finally:
@@ -72,7 +72,7 @@ def test_conversion_incomplete_conversion(client):
     '''
     conversion = client.conversion_new(mmd=mmd, convert_to_docx=True)
     with pytest.raises(ConversionIncompleteError):
-        conversion.docx()
+        conversion.to_docx_bytes()
 
 if __name__ == '__main__':
     client = MathpixClient()

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -29,7 +29,7 @@ def test_image_conversion_local_file(client):
     image_file_path = os.path.join(current_dir, "files/images/code_5.jpg")
     assert os.path.exists(image_file_path), f"Test input file not found: {image_file_path}"
     image = client.image_new(
-        url=image_file_path
+        file_path=image_file_path
     )
     mmd_result = image.mmd()
     assert mmd_result is not None
@@ -40,16 +40,18 @@ def test_conversion_from_image_output(client):
     image_file_path = os.path.join(current_dir, "files/images/cases_hw.png")
     assert os.path.exists(image_file_path), f"Test input file not found: {image_file_path}"
     image = client.image_new(
-        url=image_file_path
+        file_path=image_file_path
     )
     mmd = image.mmd()
     assert mmd is not None and len(mmd) > 0
-    conversion = client.conversion_new(mmd=mmd, conversion_formats={"docx": True})
+    conversion = client.conversion_new(mmd=mmd, convert_to_docx=True)
     completed = conversion.wait_until_complete(timeout=20)
     assert completed, "Conversion from MMD did not complete"
     output_dir = "output"
+    output_file = 'cases_hw.docx'
+    output_path = os.path.join(output_dir, output_file)
     os.mkdir(output_dir)
-    file_path_obj = conversion.download_output_to_local_path("docx", output_dir)
+    file_path_obj = conversion.save_docx_file(path=output_path)
     file_path_str = str(file_path_obj)
     assert os.path.exists(file_path_str), f"Downloaded file does not exist at {file_path_str}"
     assert os.path.getsize(file_path_str) > 0, f"Downloaded file {file_path_str} is empty"
@@ -61,11 +63,8 @@ def test_invalid_image_arguments(client):
     image_file_path = os.path.join(current_dir, "files/images/cases_hw.png")
     assert os.path.exists(image_file_path), f"Test input file not found: {image_file_path}"
     with pytest.raises(ValidationError):
-        image = client.image_new(file_path=image_file_path, file_url=image_file_url)
+        image = client.image_new(file_path=image_file_path, url=image_file_url)
 
 
 if __name__ == '__main__':
     client = MathpixClient()
-    # test_image_conversion_remote_file(client)
-    # test_image_conversion_local_file(client)
-    # test_conversion_from_image_output(client)

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -15,7 +15,7 @@ def client():
 def test_image_conversion_remote_file(client):
     image_file_url = "https://mathpix-ocr-examples.s3.amazonaws.com/cases_hw.jpg"
     image = client.image_new(
-        file_url=image_file_url,
+        url=image_file_url,
     )
     lines_result = image.lines_json()
     assert lines_result is not None
@@ -29,7 +29,7 @@ def test_image_conversion_local_file(client):
     image_file_path = os.path.join(current_dir, "files/images/code_5.jpg")
     assert os.path.exists(image_file_path), f"Test input file not found: {image_file_path}"
     image = client.image_new(
-        file_path=image_file_path
+        url=image_file_path
     )
     mmd_result = image.mmd()
     assert mmd_result is not None
@@ -40,7 +40,7 @@ def test_conversion_from_image_output(client):
     image_file_path = os.path.join(current_dir, "files/images/cases_hw.png")
     assert os.path.exists(image_file_path), f"Test input file not found: {image_file_path}"
     image = client.image_new(
-        file_path=image_file_path
+        url=image_file_path
     )
     mmd = image.mmd()
     assert mmd is not None and len(mmd) > 0

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -51,7 +51,7 @@ def test_conversion_from_image_output(client):
     output_file = 'cases_hw.docx'
     output_path = os.path.join(output_dir, output_file)
     os.mkdir(output_dir)
-    file_path_obj = conversion.save_docx_file(path=output_path)
+    file_path_obj = conversion.to_docx_file(path=output_path)
     file_path_str = str(file_path_obj)
     assert os.path.exists(file_path_str), f"Downloaded file does not exist at {file_path_str}"
     assert os.path.getsize(file_path_str) > 0, f"Downloaded file {file_path_str} is empty"
@@ -63,7 +63,7 @@ def test_invalid_image_arguments(client):
     image_file_path = os.path.join(current_dir, "files/images/cases_hw.png")
     assert os.path.exists(image_file_path), f"Test input file not found: {image_file_path}"
     with pytest.raises(ValidationError):
-        image = client.image_new(file_path=image_file_path, url=image_file_url)
+        client.image_new(file_path=image_file_path, url=image_file_url)
 
 
 if __name__ == '__main__':

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -1,5 +1,7 @@
 import os
 import shutil
+from typing import Dict
+
 import pytest
 
 from mpxpy.errors import ConversionIncompleteError, ValidationError
@@ -15,124 +17,128 @@ def client():
 
 def test_pdf_convert_remote_file(client):
     pdf_file_url = "https://mathpix-ocr-examples.s3.amazonaws.com/bitcoin-7.pdf"
-    pdf_file = client.pdf_new(
-        file_url=pdf_file_url,
+    pdf = client.pdf_new(
+        url=pdf_file_url
     )
-    assert pdf_file.pdf_id is not None
-    assert pdf_file.wait_until_complete(timeout=60)
-    status = pdf_file.pdf_status()
+    assert pdf.pdf_id is not None
+    assert pdf.wait_until_complete(timeout=60)
+    status = pdf.pdf_status()
     assert status['status'] == 'completed'
 
 def test_pdf_convert_remote_file_to_docx(client):
     pdf_file_url = "https://mathpix-ocr-examples.s3.amazonaws.com/bitcoin-7.pdf"
-    pdf_file = client.pdf_new(
-        file_url=pdf_file_url,
-        conversion_formats={
-            "docx": True
-        }
+    pdf = client.pdf_new(
+        url=pdf_file_url,
+        convert_to_md=True
     )
-    assert pdf_file.pdf_id is not None
-    assert pdf_file.wait_until_complete(timeout=60)
-    status = pdf_file.pdf_status()
+    assert pdf.pdf_id is not None
+    assert pdf.wait_until_complete(timeout=60)
+    status = pdf.pdf_status()
     assert status['status'] == 'completed'
 
 
 def test_pdf_convert_local_file(client):
     pdf_file_path = os.path.join(current_dir, "files/pdfs/sample.pdf")
     assert os.path.exists(pdf_file_path), f"Test input file not found: {pdf_file_path}"
-    pdf_file = client.pdf_new(
+    pdf = client.pdf_new(
         file_path=pdf_file_path,
-        conversion_formats={
-            "docx": True
-        }
+        convert_to_md=True
     )
-    assert pdf_file.pdf_id is not None
-    assert pdf_file.wait_until_complete(timeout=60)
-    status = pdf_file.pdf_status()
+    assert pdf.pdf_id is not None
+    assert pdf.wait_until_complete(timeout=60)
+    status = pdf.pdf_status()
     assert status['status'] == 'completed'
 
 
-def test_pdf_download_conversion(client):
+def test_pdf_save_md_to_local_path(client):
     pdf_file_path = os.path.join(current_dir, "files/pdfs/the-internet-tidal-wave.pdf")
     assert os.path.exists(pdf_file_path), f"Test input file not found: {pdf_file_path}"
-    pdf_file = client.pdf_new(
-        file_path=pdf_file_path,
-        conversion_formats={
-            "docx": True
-        }
-    )
-    assert pdf_file.pdf_id is not None
-    completed = pdf_file.wait_until_complete(timeout=60)
-    assert completed
-    output_dir = 'output'
-    os.mkdir(output_dir)
-    file_path = pdf_file.download_output_to_local_path('docx', output_dir)
-    assert os.path.exists(file_path)
-    if output_dir and os.path.isdir(output_dir):
-        shutil.rmtree(output_dir)
-
-
-def test_pdf_get_result_bytes(client):
-    pdf_file_path = os.path.join(current_dir, "files/pdfs/theres-plenty-of-room-at-the-bottom.pdf")
-    assert os.path.exists(pdf_file_path), f"Test input file not found: {pdf_file_path}"
-    pdf_file = client.pdf_new(
-        file_path=pdf_file_path,
-        conversion_formats={
-            "docx": True
-        }
-    )
-    assert pdf_file.pdf_id is not None
-    assert pdf_file.wait_until_complete(timeout=60)
-    raw = pdf_file.download_output('md')
-    assert raw is not None
-
-def test_pdf_download_to_local_path(client):
-    pdf_file_url = "https://mathpix-ocr-examples.s3.amazonaws.com/bitcoin-7.pdf"
     pdf = client.pdf_new(
-        file_url=pdf_file_url,
-        conversion_formats={
-            "docx": True
-        }
+        file_path=pdf_file_path,
+        convert_to_md=True
     )
     assert pdf.pdf_id is not None
-    output_dir = pdf.pdf_id
+    completed = pdf.wait_until_complete(timeout=60)
+    assert completed
+    output_dir = 'output'
+    output_name = 'the-internet-tidal-wave.md'
+    output_path = os.path.join(output_dir, output_name)
+    file_path = pdf.save_md_file(path=output_path)
     try:
-        pdf.wait_until_complete(timeout=10)
-        path = pdf.download_output_to_local_path('docx', path=output_dir)
-        assert os.path.exists(path)
-        assert os.path.getsize(path) > 0
+        assert os.path.exists(file_path)
+        assert os.path.getsize(file_path) > 0
     finally:
         if os.path.exists(output_dir) and os.path.isdir(output_dir):
             shutil.rmtree(output_dir)
 
+
+def test_pdf_get_result_md_text(client):
+    pdf_file_path = os.path.join(current_dir, "files/pdfs/theres-plenty-of-room-at-the-bottom.pdf")
+    assert os.path.exists(pdf_file_path), f"Test input file not found: {pdf_file_path}"
+    pdf = client.pdf_new(
+        file_path=pdf_file_path,
+        convert_to_md=True
+    )
+    assert pdf.pdf_id is not None
+    assert pdf.wait_until_complete(timeout=60)
+    md_output = pdf.md()
+    assert md_output is not None
+    assert isinstance(md_output, str), f"Expected md output to be a string, got {type(md_output)}"
+
+def test_pdf_get_result_lines_json(client):
+    pdf_file_path = os.path.join(current_dir, "files/pdfs/sample.pdf")
+    assert os.path.exists(pdf_file_path), f"Test input file not found: {pdf_file_path}"
+    pdf = client.pdf_new(
+        file_path=pdf_file_path
+    )
+    assert pdf.pdf_id is not None
+    assert pdf.wait_until_complete(timeout=60)
+    lines_json = pdf.lines_json()
+    assert lines_json is not None
+    assert isinstance(lines_json, Dict), f"Expected lines.json output to be a dict, got {type(lines_json)}"
+
+def test_pdf_get_result_docx(client):
+    pdf_file_path = os.path.join(current_dir, "files/pdfs/sample.pdf")
+    assert os.path.exists(pdf_file_path), f"Test input file not found: {pdf_file_path}"
+    pdf = client.pdf_new(
+        file_path=pdf_file_path,
+        convert_to_docx=True
+    )
+    assert pdf.pdf_id is not None
+    assert pdf.wait_until_complete(timeout=60)
+    docx_bytes = pdf.docx()
+    assert docx_bytes is not None
+    assert isinstance(docx_bytes, bytes), f"Expected docx output to be of type bytes, got {type(docx_bytes)}"
+
+
 def test_pdf_download_output_incomplete_conversion(client):
     pdf_file_url = "https://mathpix-ocr-examples.s3.amazonaws.com/bitcoin-7.pdf"
-    pdf_file = client.pdf_new(
-        file_url=pdf_file_url,
-        conversion_formats={
-            "docx": True
-        }
+    pdf = client.pdf_new(
+        url=pdf_file_url,
+        convert_to_md=True
     )
     with pytest.raises(ConversionIncompleteError):
-        pdf_file.download_output(conversion_format='docx')
+        pdf.md()
 
 def test_invalid_pdf_arguments(client):
     pdf_file_url = "https://mathpix-ocr-examples.s3.amazonaws.com/bitcoin-7.pdf"
     pdf_file_path = os.path.join(current_dir, "files/pdfs/theres-plenty-of-room-at-the-bottom.pdf")
     assert os.path.exists(pdf_file_path), f"Test input file not found: {pdf_file_path}"
     with pytest.raises(ValidationError):
-        pdf = client.pdf_new(file_path=pdf_file_path, file_url=pdf_file_url)
+        client.pdf_new(file_path=pdf_file_path, url=pdf_file_url)
 
 def test_bad_pdf_path(client):
     pdf_file_path = os.path.join(current_dir, "files/pdfs/nonexistent.pdf")
     with pytest.raises(FileNotFoundError):
-        pdf = client.pdf_new(file_path=pdf_file_path)
+        client.pdf_new(file_path=pdf_file_path)
 
 
 if __name__ == '__main__':
     client = MathpixClient()
-    # test_pdf_convert_remote_file(client)
-    # test_pdf_convert_remote_file_to_docx(client)
-    # test_pdf_convert_local_file(client)
-    # test_pdf_download_conversion(client)
-    # test_pdf_get_result_bytes(client)
+    pdf_file_path = os.path.join(current_dir, "files/pdfs/sample.pdf")
+    pdf = client.pdf_new(
+        file_path=pdf_file_path
+    )
+    completed = pdf.wait_until_complete(timeout=60)
+    output_path = 'output/lines.json'
+    file_path = pdf.save_lines_json(path=output_path)

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -63,7 +63,7 @@ def test_pdf_save_md_to_local_path(client):
     output_dir = 'output'
     output_name = 'the-internet-tidal-wave.md'
     output_path = os.path.join(output_dir, output_name)
-    file_path = pdf.save_md_file(path=output_path)
+    file_path = pdf.to_md_file(path=output_path)
     try:
         assert os.path.exists(file_path)
         assert os.path.getsize(file_path) > 0
@@ -81,7 +81,7 @@ def test_pdf_get_result_md_text(client):
     )
     assert pdf.pdf_id is not None
     assert pdf.wait_until_complete(timeout=60)
-    md_output = pdf.md()
+    md_output = pdf.to_md_text()
     assert md_output is not None
     assert isinstance(md_output, str), f"Expected md output to be a string, got {type(md_output)}"
 
@@ -93,7 +93,7 @@ def test_pdf_get_result_lines_json(client):
     )
     assert pdf.pdf_id is not None
     assert pdf.wait_until_complete(timeout=60)
-    lines_json = pdf.lines_json()
+    lines_json = pdf.to_lines_json()
     assert lines_json is not None
     assert isinstance(lines_json, Dict), f"Expected lines.json output to be a dict, got {type(lines_json)}"
 
@@ -106,7 +106,7 @@ def test_pdf_get_result_docx(client):
     )
     assert pdf.pdf_id is not None
     assert pdf.wait_until_complete(timeout=60)
-    docx_bytes = pdf.docx()
+    docx_bytes = pdf.to_docx_bytes()
     assert docx_bytes is not None
     assert isinstance(docx_bytes, bytes), f"Expected docx output to be of type bytes, got {type(docx_bytes)}"
 
@@ -118,7 +118,7 @@ def test_pdf_download_output_incomplete_conversion(client):
         convert_to_md=True
     )
     with pytest.raises(ConversionIncompleteError):
-        pdf.md()
+        pdf.to_md_text()
 
 def test_invalid_pdf_arguments(client):
     pdf_file_url = "https://mathpix-ocr-examples.s3.amazonaws.com/bitcoin-7.pdf"

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -135,10 +135,3 @@ def test_bad_pdf_path(client):
 
 if __name__ == '__main__':
     client = MathpixClient()
-    pdf_file_path = os.path.join(current_dir, "files/pdfs/sample.pdf")
-    pdf = client.pdf_new(
-        file_path=pdf_file_path
-    )
-    completed = pdf.wait_until_complete(timeout=60)
-    output_path = 'output/lines.json'
-    file_path = pdf.save_lines_json(path=output_path)


### PR DESCRIPTION
Significantly updates the client interface, as documented in the README. 

## PDFs

PDFs now use:
- Separate arguments to specify conversion formats
- New methods to save to local path and get the result
  - 'docx', 'html', 'tex.zip', and 'pdf' results are returned as `bytes`
  - 'md' and 'mmd' results are returned as `str`
  - 'lines.json' and 'lines.mmd.json' results are returned as 'Dict'
  - 'path' argument will require inclusion of the output file name

```python
from mpxpy.mathpix_client import MathpixClient

client = MathpixClient(
    app_id="your-app-id",
    app_key="your-app-key"
)

# Process a PDF file
pdf = client.pdf_new(
    url="http://cs229.stanford.edu/notes2020spring/cs229-notes1.pdf",
    convert_to_docx=True,
    convert_to_md=True,
)

# Wait for processing to complete. Optional timeout argument is 60 seconds by default.
pdf.wait_until_complete(timeout=30)

# Get the Markdown outputs
md_output_path = pdf.save_md_file(path='output/sample.md')
md_text = pdf.md() # is type str
print(md_text)
# Get the DOCX outputs
docx_output_path = pdf.save_docx_file(path='output/sample.docx')
docx_bytes = pdf.docx() # is type bytes
# Get the JSON outputs
lines_json_output_path = pdf.save_lines_json(path='output/sample.lines.json')
lines_json = pdf.lines_json() # is type Dict
```

## Images

Images now use:
- url for image URLs rather than file_url

```python
from mpxpy.mathpix_client import MathpixClient

client = MathpixClient(
    app_id="your-app-id",
    app_key="your-app-key"
)
# Process an image file
image = client.image_new(
    url="https://mathpix-ocr-examples.s3.amazonaws.com/cases_hw.jpg"
)

# Get the Mathpix Markdown (MMD) representation
mmd = image.mmd()
print(mmd)

# Get line-by-line OCR data
lines = image.lines_json()
print(lines)
```

## Conversions

Conversions now follow the same conventions as PDFs

```python
from mpxpy.mathpix_client import MathpixClient

client = MathpixClient(
    app_id="your-app-id",
    app_key="your-app-key"
)

# Convert Mathpix Markdown to various formats
conversion = client.conversion_new(
    mmd="\\frac{1}{2}",
    convert_to_docx=True,
    convert_to_md=True,
)

# Wait for conversion to complete
conversion.wait_until_complete(timeout=30)

# Get the Markdown outputs
md_output_path = conversion.save_md_file(path='output/sample.md')
md_text = conversion.md() # is of type str
# Get the DOCX outputs
docx_output_path = conversion.save_docx_file(path='output/sample.docx')
docx_bytes = conversion.docx() # is of type bytes
```