### PR TITLE
[mpxpy] Fix noisy logging defaults and fix failing test

### DIFF
--- a/mpxpy/auth.py
+++ b/mpxpy/auth.py
@@ -77,12 +77,12 @@ class Auth:
         for config_path in config_locations:
             if config_path.exists():
                 try:
-                    logger.info(f"Loading config from {config_path}")
+                    logger.debug(f"Loading config from {config_path}")
                     load_dotenv(config_path)
                     return True
                 except Exception as e:
                     logger.warning(f"Error loading config from {config_path}: {str(e)}")
-        logger.info("No config files found")
+        logger.debug("No config files found")
         return False
 
     def _validate_api_url(self, url: str) -> str:

--- a/mpxpy/conversion.py
+++ b/mpxpy/conversion.py
@@ -99,7 +99,7 @@ class Conversion:
         """
         if not isinstance(timeout, int) or timeout <= 0:
             raise ValidationError("Timeout must be a positive, non-zero integer")
-        logger.info(f"Waiting for conversion {self.conversion_id} to complete (timeout: {timeout}s)")
+        logger.debug(f"Waiting for conversion {self.conversion_id} to complete (timeout: {timeout}s)")
         attempt = 1
         completed = False
         while attempt < timeout and not completed:
@@ -110,14 +110,14 @@ class Conversion:
                     for _, format_data in conversion_status['conversion_status'].items()
             )):
                 completed = True
-                logger.info(f"Conversion {self.conversion_id} completed successfully")
+                logger.debug(f"Conversion {self.conversion_id} completed successfully")
                 break
             elif conversion_status['status'] == 'error':
                 break
             time.sleep(1)
             attempt += 1
         if not completed:
-            logger.debug(f"Conversion {self.conversion_id} did not complete within timeout period ({timeout}s)")
+            logger.warning(f"Conversion {self.conversion_id} did not complete within timeout period ({timeout}s)")
         return completed
 
     def conversion_status(self):
@@ -126,7 +126,7 @@ class Conversion:
         Returns:
             dict: JSON response containing conversion status information.
         """
-        logger.info(f"Getting status for conversion {self.conversion_id}")
+        logger.debug(f"Getting status for conversion {self.conversion_id}")
         endpoint = urljoin(self.auth.api_url, f'v3/converter/{self.conversion_id}')
         response = get(endpoint, headers=self.auth.headers, **self.request_options)
         return response.json()
@@ -147,7 +147,7 @@ class Conversion:
         if path.endswith('/') or path.endswith('\\'):
             filename = f"{self.conversion_id}.{conversion_format}"
             path = os.path.join(path, filename)
-        logger.info(f"Downloading output for Conversion {self.conversion_id} in format {conversion_format} to path {path}")
+        logger.debug(f"Downloading output for Conversion {self.conversion_id} in format {conversion_format} to path {path}")
         endpoint = urljoin(self.auth.api_url, f'v3/converter/{self.conversion_id}.{conversion_format}')
         response = get(endpoint, headers=self.auth.headers, **self.request_options)
         if response.status_code == 404:
@@ -162,7 +162,7 @@ class Conversion:
                         f.write(chunk)
         except Exception:
             raise FilesystemError('Failed to save file to system')
-        logger.info(f"File saved successfully to {path}")
+        logger.debug(f"File saved successfully to {path}")
         return path
 
     def text_result(self, conversion_format: str) -> str:
@@ -177,7 +177,7 @@ class Conversion:
         Raises:
             ConversionIncompleteError: If the conversion is not complete
         """
-        logger.info(f"Downloading output for conversion {self.conversion_id} in format: {conversion_format}")
+        logger.debug(f"Downloading output for conversion {self.conversion_id} in format: {conversion_format}")
         endpoint = urljoin(self.auth.api_url, f'v3/converter/{self.conversion_id}.{conversion_format}')
         response = get(endpoint, headers=self.auth.headers, **self.request_options)
         if response.status_code == 404:
@@ -196,7 +196,7 @@ class Conversion:
         Raises:
             ConversionIncompleteError: If the conversion is not complete
         """
-        logger.info(f"Downloading output for conversion {self.conversion_id} in format: {conversion_format}")
+        logger.debug(f"Downloading output for conversion {self.conversion_id} in format: {conversion_format}")
         endpoint = urljoin(self.auth.api_url, f'v3/converter/{self.conversion_id}.{conversion_format}')
         response = get(endpoint, headers=self.auth.headers, **self.request_options)
         if response.status_code == 404:

--- a/mpxpy/file_batch.py
+++ b/mpxpy/file_batch.py
@@ -57,7 +57,7 @@ class FileBatch:
             bool: True if any files in the batch are still processing, False if all
                  files are either completed or have errored out.
         """
-        logger.info(f"Checking if file batch {self.file_batch_id} is still processing")
+        logger.debug(f"Checking if file batch {self.file_batch_id} is still processing")
         endpoint = urljoin(self.auth.api_url, f'v3/file-batches/{self.file_batch_id}')
         response = get(endpoint, headers=self.auth.headers, **self.request_options)
         response_json = response.json()
@@ -65,7 +65,7 @@ class FileBatch:
         completed_files = response_json["completed_files"]
         error_files = response_json["error_files"]
         still_processing = total_files != completed_files + error_files
-        logger.info(f"Batch status: {completed_files}/{total_files} completed, {error_files} errors, still processing: {still_processing}")
+        logger.debug(f"Batch status: {completed_files}/{total_files} completed, {error_files} errors, still processing: {still_processing}")
         return still_processing
 
     def file_batch_status(self):
@@ -75,7 +75,7 @@ class FileBatch:
             dict: JSON response containing batch status information including counts
                  of total, completed, and error files.
         """
-        logger.info(f"Getting status for file batch {self.file_batch_id}")
+        logger.debug(f"Getting status for file batch {self.file_batch_id}")
         endpoint =  urljoin(self.auth.api_url, f'v3/file-batches/{self.file_batch_id}')
         response = get(endpoint, headers=self.auth.headers, **self.request_options)
         return response.json()
@@ -92,7 +92,7 @@ class FileBatch:
                 - cursor (str): Pagination cursor for the next page.
                 - has_more (bool): Whether more pages of results are available.
         """
-        logger.info(f"Retrieving files for batch {self.file_batch_id}")
+        logger.debug(f"Retrieving files for batch {self.file_batch_id}")
         endpoint =  urljoin(self.auth.api_url, f'v3/file-batches/{self.file_batch_id}/files')
         if cursor:
             endpoint += f"?cursor={cursor}"
@@ -120,7 +120,7 @@ class FileBatch:
         """
         if not isinstance(timeout, int) or timeout <= 0:
             raise ValueError("Timeout must be a positive, non-zero integer")
-        logger.info(f"Waiting for file batch {self.file_batch_id} to complete (timeout: {timeout}s)")
+        logger.debug(f"Waiting for file batch {self.file_batch_id} to complete (timeout: {timeout}s)")
         attempts = 1
         completed = False
         while attempts < timeout:
@@ -130,10 +130,10 @@ class FileBatch:
             error_count = file_batch_status["error_files"]
             if total == completed_count + error_count:
                 completed = True
-                logger.info(
+                logger.debug(
                     f"File batch {self.file_batch_id} completed: {completed_count} successful, {error_count} errors, {total} total")
                 break
-            logger.info(f"File batch processing... Status: {completed_count}/{total} completed, {error_count} errors")
+            logger.debug(f"File batch processing... Status: {completed_count}/{total} completed, {error_count} errors")
             time.sleep(1)
             attempts += 1
         if not completed:

--- a/mpxpy/logger.py
+++ b/mpxpy/logger.py
@@ -9,11 +9,11 @@ def configure_logging(level=None):
 
     Args:
         level: Optional logging level (e.g., logging.INFO, logging.DEBUG).
-              If None, uses LOG_LEVEL environment variable or defaults to INFO.
+              If None, uses MATHPIX_LOG_LEVEL environment variable or defaults to WARNING.
     """
     if level is None:
-        level_name = os.getenv("MATHPIX_LOG_LEVEL", "INFO")
-        level = getattr(logging, level_name, logging.INFO)
+        level_name = os.getenv("MATHPIX_LOG_LEVEL", "WARNING")
+        level = getattr(logging, level_name, logging.WARNING)
     logger.setLevel(level)
     if not logger.handlers:
         handler = logging.StreamHandler()

--- a/mpxpy/mathpix_client.py
+++ b/mpxpy/mathpix_client.py
@@ -32,12 +32,12 @@ class MathpixClient:
             improve_mathpix: Optional boolean to enable Mathpix to retain user output. Default is true.
             request_options: Optional dict of keyword arguments to pass to the requests library (e.g. {'verify': False} for SSL verification).
         """
-        logger.info("Initializing MathpixClient")
+        logger.debug("Initializing MathpixClient")
         self.auth = Auth(app_id=app_id, app_key=app_key, api_url=api_url)
         configure_logging()
         self.improve_mathpix = improve_mathpix
         self.request_options = request_options or {}
-        logger.info(f"MathpixClient initialized with API URL: {self.auth.api_url}")
+        logger.debug(f"MathpixClient initialized with API URL: {self.auth.api_url}")
 
     def image_new(
             self,
@@ -191,7 +191,7 @@ class MathpixClient:
         if fullwidth_punctuation:
             image_options["fullwidth_punctuation"] = fullwidth_punctuation
         if not self.improve_mathpix:
-            logger.info('improve_mathpix set to False on the client')
+            logger.debug('improve_mathpix set to False on the client')
             image_options["metadata"]["improve_mathpix"] = False
         elif not improve_mathpix:
             image_options["metadata"]["improve_mathpix"] = False
@@ -342,7 +342,7 @@ class MathpixClient:
             logger.error("Invalid parameters: Exactly one of file_path or url must be provided")
             raise ValidationError("Exactly one of file_path or url must be provided")
         if not self.improve_mathpix:
-            logger.info('improve_mathpix set to False on the client')
+            logger.debug('improve_mathpix set to False on the client')
             improve_mathpix = False
         elif not improve_mathpix:
             improve_mathpix = False
@@ -427,7 +427,7 @@ class MathpixClient:
             "options_json": json.dumps(options)
         }
         if file_path:
-            logger.info(f"Creating new PDF: path={file_path}")
+            logger.debug(f"Creating new PDF: path={file_path}")
             path = Path(file_path)
             if not path.is_file():
                 logger.error(f"File not found: {file_path}")
@@ -439,7 +439,7 @@ class MathpixClient:
                     response.raise_for_status()
                     response_json = response.json()
                     pdf_id = response_json['pdf_id']
-                    logger.info(f"PDF from local path processing started, PDF ID: {pdf_id}")
+                    logger.debug(f"PDF from local path processing started, PDF ID: {pdf_id}")
                     return Pdf(
                         auth=self.auth,
                         pdf_id=pdf_id,
@@ -464,17 +464,17 @@ class MathpixClient:
                     )
                 except requests.exceptions.RequestException as e:
                     if response_json:
-                        logger.info(f"PDF upload failed: {response_json}")
+                        logger.error(f"PDF upload failed: {response_json}")
                     raise MathpixClientError(f"Mathpix PDF request failed: {e}")
         else:
-            logger.info(f"Creating new PDF: url={url}")
+            logger.debug(f"Creating new PDF: url={url}")
             options["url"] = url
             try:
                 response = post(endpoint, json=options, headers=self.auth.headers, **self.request_options)
                 response.raise_for_status()
                 response_json = response.json()
                 pdf_id = response_json['pdf_id']
-                logger.info(f"PDF from URL processing started, PDF ID: {pdf_id}")
+                logger.debug(f"PDF from URL processing started, PDF ID: {pdf_id}")
                 return Pdf(
                         auth=self.auth,
                         pdf_id=pdf_id,
@@ -499,7 +499,7 @@ class MathpixClient:
                     )
             except Exception as e:
                 if response_json:
-                    logger.info(f"PDF upload failed: {response_json}")
+                    logger.error(f"PDF upload failed: {response_json}")
                 raise MathpixClientError(f"Mathpix PDF request failed: {e}")
 
     def file_batch_new(self):
@@ -559,7 +559,7 @@ class MathpixClient:
         Raises:
             MathpixClientError: If the API request fails.
         """
-        logger.info(f"Starting new MMD conversions to")
+        logger.debug("Starting new MMD conversion")
         endpoint = urljoin(self.auth.api_url, 'v3/converter')
         options = {
             "mmd": mmd,
@@ -595,7 +595,7 @@ class MathpixClient:
                 logger.error(f"Conversion failed: {response_json}")
                 raise MathpixClientError(f"Conversion failed: {response_json}")
             conversion_id = response_json['conversion_id']
-            logger.info(f"Conversion created, ID: {conversion_id}")
+            logger.debug(f"Conversion created, ID: {conversion_id}")
             return Conversion(
                 auth=self.auth,
                 conversion_id=conversion_id,
@@ -613,5 +613,5 @@ class MathpixClient:
             )
         except Exception as e:
             if response_json:
-                logger.info(f"PDF upload failed: {response_json}")
-            raise MathpixClientError(f"Mathpix PDF request failed: {e}")
+                logger.error(f"Conversion failed: {response_json}")
+            raise MathpixClientError(f"Mathpix conversion request failed: {e}")

--- a/mpxpy/pdf.py
+++ b/mpxpy/pdf.py
@@ -132,7 +132,7 @@ class Pdf:
         """
         if not isinstance(timeout, int) or timeout <= 0:
             raise ValueError("Timeout must be a positive, non-zero integer")
-        logger.info(f"Waiting for PDF {self.pdf_id} to complete (timeout: {timeout}s, ignore_conversions: {ignore_conversions})")
+        logger.debug(f"Waiting for PDF {self.pdf_id} to complete (timeout: {timeout}s, ignore_conversions: {ignore_conversions})")
         attempt = 1
         pdf_completed = False
         conversion_completed = False
@@ -142,7 +142,7 @@ class Pdf:
                 logger.debug(f"PDF status check attempt {attempt}/{timeout}: {status}")
                 if isinstance(status, dict) and 'status' in status and status['status'] == 'completed':
                     pdf_completed = True
-                    logger.info(f"PDF {self.pdf_id} processing completed")
+                    logger.debug(f"PDF {self.pdf_id} processing completed")
                     break
                 elif isinstance(status, dict) and 'error' in status:
                     logger.error(f"Error in PDF {self.pdf_id} processing: {status.get('error')}")
@@ -154,7 +154,7 @@ class Pdf:
             time.sleep(1)
         automatic_conversion_requested = self.convert_to_docx or self.convert_to_md or self.convert_to_mmd or self.convert_to_tex_zip or self.convert_to_html or self.convert_to_pdf
         if pdf_completed and automatic_conversion_requested and not ignore_conversions:
-            logger.info(f"Checking conversion status for PDF {self.pdf_id}")
+            logger.debug(f"Checking conversion status for PDF {self.pdf_id}")
             while attempt < timeout and not conversion_completed:
                 try:
                     conv_status = self.pdf_conversion_status()
@@ -170,7 +170,7 @@ class Pdf:
                         'conversion_status' in conv_status and
                         all(format_data['status'] == 'completed'
                             for _, format_data in conv_status['conversion_status'].items())):
-                        logger.info(f"All conversions completed for PDF {self.pdf_id}")
+                        logger.debug(f"All conversions completed for PDF {self.pdf_id}")
                         conversion_completed = True
                         break
                     else:
@@ -180,7 +180,7 @@ class Pdf:
                 attempt += 1
                 time.sleep(1)
         result = pdf_completed and (conversion_completed or ignore_conversions or not automatic_conversion_requested)
-        logger.info(f"Wait completed for PDF {self.pdf_id}, result: {result}")
+        logger.debug(f"Wait completed for PDF {self.pdf_id}, result: {result}")
         return result
 
     def pdf_status(self):
@@ -221,7 +221,7 @@ class Pdf:
         if path.endswith('/') or path.endswith('\\'):
             filename = f"{self.pdf_id}.{conversion_format}"
             path = os.path.join(path, filename)
-        logger.info(f"Downloading output for PDF {self.pdf_id} in format {conversion_format} to path {path}")
+        logger.debug(f"Downloading output for PDF {self.pdf_id} in format {conversion_format} to path {path}")
         endpoint = urljoin(self.auth.api_url, f'v3/pdf/{self.pdf_id}.{conversion_format}')
         response = get(endpoint, headers=self.auth.headers, **self.request_options)
         if response.status_code == 404:
@@ -236,7 +236,7 @@ class Pdf:
                         f.write(chunk)
         except Exception:
             raise FilesystemError('Failed to save file to system')
-        logger.info(f"File saved successfully to {path}")
+        logger.debug(f"File saved successfully to {path}")
         return path
 
     def json_result(self, conversion_format: str) -> Dict:
@@ -251,7 +251,7 @@ class Pdf:
         Raises:
             ConversionIncompleteError: If the conversion is not complete
         """
-        logger.info(f"Downloading output for PDF {self.pdf_id} in format: {conversion_format}")
+        logger.debug(f"Downloading output for PDF {self.pdf_id} in format: {conversion_format}")
         endpoint = urljoin(self.auth.api_url, f'v3/pdf/{self.pdf_id}.{conversion_format}')
         response = get(endpoint, headers=self.auth.headers, **self.request_options)
         if response.status_code == 404:
@@ -270,7 +270,7 @@ class Pdf:
         Raises:
             ConversionIncompleteError: If the conversion is not complete
         """
-        logger.info(f"Downloading output for PDF {self.pdf_id} in format: {conversion_format}")
+        logger.debug(f"Downloading output for PDF {self.pdf_id} in format: {conversion_format}")
         endpoint = urljoin(self.auth.api_url, f'v3/pdf/{self.pdf_id}.{conversion_format}')
         response = get(endpoint, headers=self.auth.headers, **self.request_options)
         if response.status_code == 404:
@@ -289,7 +289,7 @@ class Pdf:
         Raises:
             ConversionIncompleteError: If the conversion is not complete
         """
-        logger.info(f"Downloading output for PDF {self.pdf_id} in format: {conversion_format}")
+        logger.debug(f"Downloading output for PDF {self.pdf_id} in format: {conversion_format}")
         endpoint = urljoin(self.auth.api_url, f'v3/pdf/{self.pdf_id}.{conversion_format}')
         response = get(endpoint, headers=self.auth.headers, **self.request_options)
         if response.status_code == 404:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ requires-python = ">=3.8"
 authors = [
   { name="Nico Jimenez", email="nicodjimenez@mathpix.com" },
   { name="Matt Chang", email="mattchang@mathpix.com" },
+  { name="Sangyub Lee", email="sangyub@mathpix.com" },
 ]
 license = { file="LICENSE.txt" }
 classifiers = [

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -15,7 +15,7 @@ def client():
     return MathpixClient()
 
 
-def test_pdf_convert_remote_file(client):
+def test_pdf_convert_remote_file(client: MathpixClient):
     pdf_file_url = "https://mathpix-ocr-examples.s3.amazonaws.com/bitcoin-7.pdf"
     pdf = client.pdf_new(
         url=pdf_file_url
@@ -25,7 +25,7 @@ def test_pdf_convert_remote_file(client):
     status = pdf.pdf_status()
     assert status['status'] == 'completed'
 
-def test_pdf_convert_remote_file_to_docx(client):
+def test_pdf_convert_remote_file_to_docx(client: MathpixClient):
     pdf_file_url = "https://mathpix-ocr-examples.s3.amazonaws.com/bitcoin-7.pdf"
     pdf = client.pdf_new(
         url=pdf_file_url,
@@ -37,7 +37,7 @@ def test_pdf_convert_remote_file_to_docx(client):
     assert status['status'] == 'completed'
 
 
-def test_pdf_convert_local_file(client):
+def test_pdf_convert_local_file(client: MathpixClient):
     pdf_file_path = os.path.join(current_dir, "files/pdfs/sample.pdf")
     assert os.path.exists(pdf_file_path), f"Test input file not found: {pdf_file_path}"
     pdf = client.pdf_new(
@@ -50,7 +50,7 @@ def test_pdf_convert_local_file(client):
     assert status['status'] == 'completed'
 
 
-def test_pdf_save_md_to_local_path(client):
+def test_pdf_save_md_to_local_path(client: MathpixClient):
     pdf_file_path = os.path.join(current_dir, "files/pdfs/the-internet-tidal-wave.pdf")
     assert os.path.exists(pdf_file_path), f"Test input file not found: {pdf_file_path}"
     pdf = client.pdf_new(
@@ -72,7 +72,7 @@ def test_pdf_save_md_to_local_path(client):
             shutil.rmtree(output_dir)
 
 
-def test_pdf_get_result_md_text(client):
+def test_pdf_get_result_md_text(client: MathpixClient):
     pdf_file_path = os.path.join(current_dir, "files/pdfs/theres-plenty-of-room-at-the-bottom.pdf")
     assert os.path.exists(pdf_file_path), f"Test input file not found: {pdf_file_path}"
     pdf = client.pdf_new(
@@ -85,7 +85,7 @@ def test_pdf_get_result_md_text(client):
     assert md_output is not None
     assert isinstance(md_output, str), f"Expected md output to be a string, got {type(md_output)}"
 
-def test_pdf_get_result_lines_json(client):
+def test_pdf_get_result_lines_json(client: MathpixClient):
     pdf_file_path = os.path.join(current_dir, "files/pdfs/sample.pdf")
     assert os.path.exists(pdf_file_path), f"Test input file not found: {pdf_file_path}"
     pdf = client.pdf_new(
@@ -97,7 +97,7 @@ def test_pdf_get_result_lines_json(client):
     assert lines_json is not None
     assert isinstance(lines_json, Dict), f"Expected lines.json output to be a dict, got {type(lines_json)}"
 
-def test_pdf_get_result_docx(client):
+def test_pdf_get_result_docx(client: MathpixClient):
     pdf_file_path = os.path.join(current_dir, "files/pdfs/sample.pdf")
     assert os.path.exists(pdf_file_path), f"Test input file not found: {pdf_file_path}"
     pdf = client.pdf_new(
@@ -111,29 +111,37 @@ def test_pdf_get_result_docx(client):
     assert isinstance(docx_bytes, bytes), f"Expected docx output to be of type bytes, got {type(docx_bytes)}"
 
 
-def test_pdf_download_output_incomplete_conversion(client):
+def test_pdf_download_output_without_explicit_wait(client: MathpixClient):
+    """Test that requesting output without explicit wait_until_complete() still works.
+
+    The API now waits for conversion to complete before returning the result,
+    so we don't need to explicitly poll for completion.
+    """
     pdf_file_url = "https://mathpix-ocr-examples.s3.amazonaws.com/bitcoin-7.pdf"
     pdf = client.pdf_new(
         url=pdf_file_url,
         convert_to_md=True
     )
-    with pytest.raises(ConversionIncompleteError):
-        pdf.to_md_text()
+    # API should wait for conversion and return result (no explicit wait needed)
+    md_output = pdf.to_md_text()
+    assert md_output is not None
+    assert isinstance(md_output, str), f"Expected md output to be a string, got {type(md_output)}"
+    assert len(md_output) > 0, "Expected non-empty markdown output"
 
-def test_invalid_pdf_arguments(client):
+def test_invalid_pdf_arguments(client: MathpixClient):
     pdf_file_url = "https://mathpix-ocr-examples.s3.amazonaws.com/bitcoin-7.pdf"
     pdf_file_path = os.path.join(current_dir, "files/pdfs/theres-plenty-of-room-at-the-bottom.pdf")
     assert os.path.exists(pdf_file_path), f"Test input file not found: {pdf_file_path}"
     with pytest.raises(ValidationError):
         client.pdf_new(file_path=pdf_file_path, url=pdf_file_url)
 
-def test_bad_pdf_path(client):
+def test_bad_pdf_path(client: MathpixClient):
     pdf_file_path = os.path.join(current_dir, "files/pdfs/nonexistent.pdf")
     with pytest.raises(FileNotFoundError):
         client.pdf_new(file_path=pdf_file_path)
 
 
-def test_pdf_get_result_md_zip(client):
+def test_pdf_get_result_md_zip(client: MathpixClient):
     pdf_file_path = os.path.join(current_dir, "files/pdfs/sample.pdf")
     assert os.path.exists(pdf_file_path), f"Test input file not found: {pdf_file_path}"
     pdf = client.pdf_new(
@@ -148,7 +156,7 @@ def test_pdf_get_result_md_zip(client):
     assert md_zip_bytes.startswith(b'PK'), "Expected md.zip to be a valid ZIP file"
 
 
-def test_pdf_save_md_zip_to_local_path(client):
+def test_pdf_save_md_zip_to_local_path(client: MathpixClient):
     pdf_file_path = os.path.join(current_dir, "files/pdfs/sample.pdf")
     assert os.path.exists(pdf_file_path), f"Test input file not found: {pdf_file_path}"
     pdf = client.pdf_new(
@@ -169,7 +177,7 @@ def test_pdf_save_md_zip_to_local_path(client):
             shutil.rmtree(output_dir)
 
 
-def test_pdf_get_result_mmd_zip(client):
+def test_pdf_get_result_mmd_zip(client: MathpixClient):
     pdf_file_path = os.path.join(current_dir, "files/pdfs/sample.pdf")
     assert os.path.exists(pdf_file_path), f"Test input file not found: {pdf_file_path}"
     pdf = client.pdf_new(
@@ -184,7 +192,7 @@ def test_pdf_get_result_mmd_zip(client):
     assert mmd_zip_bytes.startswith(b'PK'), "Expected mmd.zip to be a valid ZIP file"
 
 
-def test_pdf_save_mmd_zip_to_local_path(client):
+def test_pdf_save_mmd_zip_to_local_path(client: MathpixClient):
     pdf_file_path = os.path.join(current_dir, "files/pdfs/sample.pdf")
     assert os.path.exists(pdf_file_path), f"Test input file not found: {pdf_file_path}"
     pdf = client.pdf_new(
@@ -205,7 +213,7 @@ def test_pdf_save_mmd_zip_to_local_path(client):
             shutil.rmtree(output_dir)
 
 
-def test_pdf_get_result_pptx(client):
+def test_pdf_get_result_pptx(client: MathpixClient):
     pdf_file_path = os.path.join(current_dir, "files/pdfs/sample.pdf")
     assert os.path.exists(pdf_file_path), f"Test input file not found: {pdf_file_path}"
     pdf = client.pdf_new(
@@ -220,7 +228,7 @@ def test_pdf_get_result_pptx(client):
     assert pptx_bytes.startswith(b'PK'), "Expected pptx to be a valid ZIP-based file"
 
 
-def test_pdf_save_pptx_to_local_path(client):
+def test_pdf_save_pptx_to_local_path(client: MathpixClient):
     pdf_file_path = os.path.join(current_dir, "files/pdfs/sample.pdf")
     assert os.path.exists(pdf_file_path), f"Test input file not found: {pdf_file_path}"
     pdf = client.pdf_new(
@@ -240,7 +248,7 @@ def test_pdf_save_pptx_to_local_path(client):
         if os.path.exists(output_dir) and os.path.isdir(output_dir):
             shutil.rmtree(output_dir)
 
-def test_pdf_get_result_html_zip(client):
+def test_pdf_get_result_html_zip(client: MathpixClient):
     pdf_file_path = os.path.join(current_dir, "files/pdfs/sample.pdf")
     assert os.path.exists(pdf_file_path), f"Test input file not found: {pdf_file_path}"
     pdf = client.pdf_new(
@@ -255,7 +263,7 @@ def test_pdf_get_result_html_zip(client):
     assert html_zip_bytes.startswith(b'PK'), "Expected html_zip to be a valid ZIP-based file"
 
 
-def test_pdf_save_html_zip_to_local_path(client):
+def test_pdf_save_html_zip_to_local_path(client: MathpixClient):
     pdf_file_path = os.path.join(current_dir, "files/pdfs/sample.pdf")
     assert os.path.exists(pdf_file_path), f"Test input file not found: {pdf_file_path}"
     pdf = client.pdf_new(


### PR DESCRIPTION
- Default log level changed from INFO to WARNING - SDK is now silent by default
- Routine operations (init, status checks, downloads) downgraded to DEBUG
- Failures (upload errors, timeouts) upgraded to ERROR/WARNING where appropriate
- Updated test_pdf_download_output_incomplete_conversion - API now queues conversions instead of returning 404