### PR TITLE
[mpxpy] Add documented v3 request options

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ## July 24, 2026
 
+- Add documented request options to `image_new`, `pdf_new`, and `conversion_new`, plus an `extra_options` escape hatch for unmodeled API fields that cannot override modeled request fields
 - Support the public Files API v1
   - `file_new` submits a single document, taking exactly one of `source_uri` (a remote `s3://`, `gs://`, public `https://`, or Azure Blob URI, via `POST /files/v1/uri`) or `file_path` (a local file, via multipart `POST /files/v1`); both support `Idempotency-Key` retry safety, `(job_id, custom_id)` idempotency, and the `filename`, `s3_region`, and `include_page_info` options
   - `file_job_new` submits documents in bulk (with a server-enforced per-call ceiling) via `POST /files/v1/jobs`; the new `FileJob` class polls job status, lists files with a status filter and pagination iterator, and fetches files by `custom_id`

--- a/mpxpy/mathpix_client.py
+++ b/mpxpy/mathpix_client.py
@@ -189,7 +189,26 @@ class MathpixClient:
             math_display_delimiters: Optional[Tuple[str, str]] = None,
             enable_spell_check: Optional[bool] = False,
             enable_tables_fallback: Optional[bool] = False,
-            fullwidth_punctuation: Optional[bool] = None
+            fullwidth_punctuation: Optional[bool] = None,
+            disable_itemize: Optional[bool] = None,
+            disable_lstlisting: Optional[bool] = None,
+            include_chemistry: Optional[bool] = None,
+            include_page_info: Optional[bool] = None,
+            language_hint: Optional[str] = None,
+            include_text_caption: Optional[bool] = None,
+            table_ocr_algorithm: Optional[str] = None,
+            include_chart_data: Optional[bool] = None,
+            include_detection_map: Optional[bool] = None,
+            include_font_size: Optional[bool] = None,
+            force_lines: Optional[bool] = None,
+            include_stats: Optional[bool] = None,
+            include_times: Optional[bool] = None,
+            ocr: Optional[List[str]] = None,
+            skip_recrop: Optional[bool] = None,
+            format_options: Optional[Dict[str, Any]] = None,
+            beam_size: Optional[int] = None,
+            n_best: Optional[int] = None,
+            enable_document_layout: Optional[bool] = None
     ):
         r"""Process an image either from a local file or remote URL.
 
@@ -228,6 +247,25 @@ class MathpixClient:
             enable_spell_check: Optional boolean to enable a predictive mode for English handwriting
             enable_tables_fallback: Optional boolean to enable an advanced table processing algorithm that supports very large and complex tables
             fullwidth_punctuation: Optional boolean to specify whether punctuation will be fullwidth Unicode
+            disable_itemize: Optional boolean to disable itemize/enumerate list environments, rendering list items as flat lines
+            disable_lstlisting: Optional boolean to disable the lstlisting environment for code blocks
+            include_chemistry: Optional boolean to enable chemistry diagram OCR
+            include_page_info: Optional boolean to include page info in the output
+            language_hint: Optional string to hint the primary language of the document
+            include_text_caption: Optional boolean to include captions for figures and tables
+            table_ocr_algorithm: Optional string to select the table OCR algorithm
+            include_chart_data: Optional boolean to return extracted data for charts
+            include_detection_map: Optional boolean to return the detection map of content types
+            include_font_size: Optional boolean to return detected font sizes
+            force_lines: Optional boolean to force line segmentation
+            include_stats: Optional boolean to include processing stats in the result
+            include_times: Optional boolean to include per-stage timing in the result
+            ocr: Optional list specifying recognition types, any of 'math' and 'text'
+            skip_recrop: Optional boolean to skip the automatic recrop step
+            format_options: Optional dict of per-format options (see https://docs.mathpix.com/#formatoptions-object)
+            beam_size: Optional int between 1 and 10 for the beam search width
+            n_best: Optional int (<= beam_size) for the number of candidate results to return
+            enable_document_layout: Optional boolean to enable document layout analysis for "text" output
 
         Returns:
             Image: A new Image instance.
@@ -305,6 +343,44 @@ class MathpixClient:
             image_options["enable_tables_fallback"] = enable_tables_fallback
         if fullwidth_punctuation:
             image_options["fullwidth_punctuation"] = fullwidth_punctuation
+        if disable_itemize is not None:
+            image_options["disable_itemize"] = disable_itemize
+        if disable_lstlisting is not None:
+            image_options["disable_lstlisting"] = disable_lstlisting
+        if include_chemistry is not None:
+            image_options["include_chemistry"] = include_chemistry
+        if include_page_info is not None:
+            image_options["include_page_info"] = include_page_info
+        if language_hint is not None:
+            image_options["language_hint"] = language_hint
+        if include_text_caption is not None:
+            image_options["include_text_caption"] = include_text_caption
+        if table_ocr_algorithm is not None:
+            image_options["table_ocr_algorithm"] = table_ocr_algorithm
+        if include_chart_data is not None:
+            image_options["include_chart_data"] = include_chart_data
+        if include_detection_map is not None:
+            image_options["include_detection_map"] = include_detection_map
+        if include_font_size is not None:
+            image_options["include_font_size"] = include_font_size
+        if force_lines is not None:
+            image_options["force_lines"] = force_lines
+        if include_stats is not None:
+            image_options["include_stats"] = include_stats
+        if include_times is not None:
+            image_options["include_times"] = include_times
+        if ocr is not None:
+            image_options["ocr"] = ocr
+        if skip_recrop is not None:
+            image_options["skip_recrop"] = skip_recrop
+        if format_options is not None:
+            image_options["format_options"] = format_options
+        if beam_size is not None:
+            image_options["beam_size"] = beam_size
+        if n_best is not None:
+            image_options["n_best"] = n_best
+        if enable_document_layout is not None:
+            image_options["enable_document_layout"] = enable_document_layout
         if not self.improve_mathpix:
             logger.debug('improve_mathpix set to False on the client')
             image_options["metadata"]["improve_mathpix"] = False
@@ -388,6 +464,16 @@ class MathpixClient:
             mathpix_webhook_secret: Optional[str] = None,
             webhook_payload: Optional[Dict[str, Any]] = None,
             webhook_enabled_events: Optional[List[str]] = None,
+            tags: Optional[List[str]] = None,
+            disable_itemize: Optional[bool] = None,
+            disable_lstlisting: Optional[bool] = None,
+            include_chemistry: Optional[bool] = None,
+            include_page_info: Optional[bool] = None,
+            include_page_breaks: Optional[bool] = None,
+            language_hint: Optional[str] = None,
+            include_text_caption: Optional[bool] = None,
+            table_ocr_algorithm: Optional[str] = None,
+            conversion_options: Optional[Dict[str, Any]] = None,
     ) -> Pdf:
         r"""Uploads a PDF, document, or ebook from a local file or remote URL and optionally requests conversions.
 
@@ -429,6 +515,16 @@ class MathpixClient:
             mathpix_webhook_secret: Optional secret for webhook authentication. (Not yet enabled)
             webhook_payload: Optional custom payload to include in webhooks. (Not yet enabled)
             webhook_enabled_events: Optional list of events to trigger webhooks. (Not yet enabled)
+            tags: Optional list of strings which can be used to identify results using the /v3/ocr-results endpoint
+            disable_itemize: Optional boolean to disable itemize/enumerate list environments, rendering list items as flat lines
+            disable_lstlisting: Optional boolean to disable the lstlisting environment for code blocks
+            include_chemistry: Optional boolean to enable chemistry diagram OCR
+            include_page_info: Optional boolean to include page info in the output
+            include_page_breaks: Optional boolean to include page break markers in the output
+            language_hint: Optional string to hint the primary language of the document
+            include_text_caption: Optional boolean to include captions for figures and tables
+            table_ocr_algorithm: Optional string to select the table OCR algorithm
+            conversion_options: Optional dict of per-format conversion options (see https://docs.mathpix.com/#conversionoptions-object)
 
         Returns:
             Pdf: A new Pdf instance
@@ -508,6 +604,26 @@ class MathpixClient:
             options["enable_tables_fallback"] = enable_tables_fallback
         if fullwidth_punctuation:
             options["fullwidth_punctuation"] = fullwidth_punctuation
+        if tags is not None:
+            options["tags"] = tags
+        if disable_itemize is not None:
+            options["disable_itemize"] = disable_itemize
+        if disable_lstlisting is not None:
+            options["disable_lstlisting"] = disable_lstlisting
+        if include_chemistry is not None:
+            options["include_chemistry"] = include_chemistry
+        if include_page_info is not None:
+            options["include_page_info"] = include_page_info
+        if include_page_breaks is not None:
+            options["include_page_breaks"] = include_page_breaks
+        if language_hint is not None:
+            options["language_hint"] = language_hint
+        if include_text_caption is not None:
+            options["include_text_caption"] = include_text_caption
+        if table_ocr_algorithm is not None:
+            options["table_ocr_algorithm"] = table_ocr_algorithm
+        if conversion_options is not None:
+            options["conversion_options"] = conversion_options
         if file_batch_id:
             options["file_batch_id"] = file_batch_id
         if webhook_url:

--- a/mpxpy/mathpix_client.py
+++ b/mpxpy/mathpix_client.py
@@ -814,6 +814,8 @@ class MathpixClient:
             convert_to_mmd_zip: Optional[bool] = False,
             convert_to_pptx: Optional[bool] = False,
             convert_to_html_zip: Optional[bool] = False,
+            conversion_options: Optional[Dict[str, Any]] = None,
+            extra_options: Optional[Dict[str, Any]] = None,
     ):
         """Converts Mathpix Markdown (MMD) to various output formats.
 
@@ -829,6 +831,8 @@ class MathpixClient:
             convert_to_mmd_zip: Optional boolean to automatically convert your result to mmd.zip
             convert_to_pptx: Optional boolean to automatically convert your result to pptx
             convert_to_html_zip: Optional boolean to automatically convert your result to html.zip
+            conversion_options: Optional dict of per-format conversion options (see https://docs.mathpix.com/#conversionoptions-object)
+            extra_options: Optional dict of raw request options merged into the request body, taking precedence over the other arguments. Escape hatch for API options this SDK version does not model yet; values are validated server-side
 
         Returns:
             Conversion: A new Conversion instance.
@@ -862,6 +866,10 @@ class MathpixClient:
             options["formats"]['mmd.zip'] = True
         if convert_to_html_zip:
             options["formats"]['html.zip'] = True
+        if conversion_options is not None:
+            options["conversion_options"] = conversion_options
+        if extra_options:
+            options.update(extra_options)
         if len(options['formats'].items()) == 0:
             raise ValidationError("At least one format is required.")
         response_json = None

--- a/mpxpy/mathpix_client.py
+++ b/mpxpy/mathpix_client.py
@@ -119,6 +119,33 @@ def _reject_reserved_extra_options(
         )
 
 
+_IMAGE_REQUEST_OPTION_KEYS: Set[str] = {
+    'src', 'metadata', 'tags', 'async', 'callback', 'formats', 'data_options',
+    'include_detected_alphabets', 'alphabets_allowed', 'region', 'enable_blue_hsv_filter',
+    'confidence_threshold', 'confidence_rate_threshold', 'include_equation_tags',
+    'include_line_data', 'include_word_data', 'include_smiles', 'include_inchi',
+    'include_geometry_data', 'include_diagram_text', 'auto_rotate_confidence_threshold',
+    'rm_spaces', 'rm_fonts', 'idiomatic_eqn_arrays', 'idiomatic_braces',
+    'numbers_default_to_math', 'math_fonts_default_to_math', 'math_inline_delimiters',
+    'math_display_delimiters', 'enable_spell_check', 'enable_tables_fallback',
+    'fullwidth_punctuation', 'disable_itemize', 'disable_lstlisting', 'include_page_info',
+    'enable_document_layout',
+}
+
+_PDF_REQUEST_OPTION_KEYS: Set[str] = {
+    'url', 'metadata', 'alphabets_allowed', 'rm_spaces', 'rm_fonts', 'idiomatic_eqn_arrays',
+    'include_equation_tags', 'include_smiles', 'include_chemistry_as_image',
+    'include_diagram_text', 'numbers_default_to_math', 'math_inline_delimiters',
+    'math_display_delimiters', 'page_ranges', 'enable_spell_check', 'auto_number_sections',
+    'remove_section_numbering', 'preserve_section_numbering', 'enable_tables_fallback',
+    'fullwidth_punctuation', 'conversion_formats', 'file_batch_id', 'webhook_url',
+    'mathpix_webhook_secret', 'webhook_payload', 'webhook_enabled_events', 'disable_itemize',
+    'disable_lstlisting', 'include_page_info', 'include_page_breaks', 'conversion_options',
+}
+
+_CONVERSION_REQUEST_OPTION_KEYS: Set[str] = {'mmd', 'formats', 'conversion_options'}
+
+
 class MathpixClient:
     """Client for interacting with the Mathpix API.
 
@@ -192,22 +219,7 @@ class MathpixClient:
             fullwidth_punctuation: Optional[bool] = None,
             disable_itemize: Optional[bool] = None,
             disable_lstlisting: Optional[bool] = None,
-            include_chemistry: Optional[bool] = None,
             include_page_info: Optional[bool] = None,
-            language_hint: Optional[str] = None,
-            include_text_caption: Optional[bool] = None,
-            table_ocr_algorithm: Optional[str] = None,
-            include_chart_data: Optional[bool] = None,
-            include_detection_map: Optional[bool] = None,
-            include_font_size: Optional[bool] = None,
-            force_lines: Optional[bool] = None,
-            include_stats: Optional[bool] = None,
-            include_times: Optional[bool] = None,
-            ocr: Optional[List[str]] = None,
-            skip_recrop: Optional[bool] = None,
-            format_options: Optional[Dict[str, Any]] = None,
-            beam_size: Optional[int] = None,
-            n_best: Optional[int] = None,
             enable_document_layout: Optional[bool] = None,
             extra_options: Optional[Dict[str, Any]] = None
     ):
@@ -220,11 +232,11 @@ class MathpixClient:
             metadata: Optional dict to attach metadata to a request
             tags: Optional list of strings which can be used to identify results using the /v3/ocr-results endpoint
             is_async: Optional boolean to enable non-interactive requests
-            callback: Optional Callback Object (see https://docs.mathpix.com/#callback-object)
+            callback: Optional Callback Object (see https://docs.mathpix.com/reference/shared-types#callback-object)
             formats: Optional list of formats ('text', 'data', 'html', or 'latex_styled')
-            data_options: Optional DataOptions dict (see https://docs.mathpix.com/#dataoptions-object)
+            data_options: Optional DataOptions dict (see https://docs.mathpix.com/reference/post-v3-text#dataoptions-object)
             include_detected_alphabets: Optional boolean to return the detected alphabets
-            alphabets_allowed: Optional dict to list alphabets allowed in the output (see https://docs.mathpix.com/#alphabetsallowed-object)
+            alphabets_allowed: Optional dict to list alphabets allowed in the output (see https://docs.mathpix.com/reference/shared-types#alphabetsallowed-object)
             region: Optional dict to specify the image area with pixel coordinates 'top_left_x', 'top_left_y', 'width', 'height'
             enable_blue_hsv_filter: Optional boolean to enable a special mode of image processing where it processes blue hue text exclusively
             confidence_threshold: Optional number between 0 and 1 to specify a threshold for triggering confidence errors (file level threshold)
@@ -250,24 +262,9 @@ class MathpixClient:
             fullwidth_punctuation: Optional boolean to specify whether punctuation will be fullwidth Unicode
             disable_itemize: Optional boolean to disable itemize/enumerate list environments, rendering list items as flat lines
             disable_lstlisting: Optional boolean to disable the lstlisting environment for code blocks
-            include_chemistry: Optional boolean to enable chemistry diagram OCR
             include_page_info: Optional boolean to include page info in the output
-            language_hint: Optional string to hint the primary language of the document
-            include_text_caption: Optional boolean to include captions for figures and tables
-            table_ocr_algorithm: Optional string to select the table OCR algorithm
-            include_chart_data: Optional boolean to return extracted data for charts
-            include_detection_map: Optional boolean to return the detection map of content types
-            include_font_size: Optional boolean to return detected font sizes
-            force_lines: Optional boolean to force line segmentation
-            include_stats: Optional boolean to include processing stats in the result
-            include_times: Optional boolean to include per-stage timing in the result
-            ocr: Optional list specifying recognition types, any of 'math' and 'text'
-            skip_recrop: Optional boolean to skip the automatic recrop step
-            format_options: Optional dict of per-format options (see https://docs.mathpix.com/#formatoptions-object)
-            beam_size: Optional int between 1 and 10 for the beam search width
-            n_best: Optional int (<= beam_size) for the number of candidate results to return
             enable_document_layout: Optional boolean to enable document layout analysis for "text" output
-            extra_options: Optional dict of raw request options merged into the request body, taking precedence over the other arguments. Escape hatch for API options this SDK version does not model yet; values are validated server-side
+            extra_options: Optional dict of unmodeled request options. Modeled request fields are rejected; values are validated server-side
 
         Returns:
             Image: A new Image instance.
@@ -278,6 +275,7 @@ class MathpixClient:
         if (file_path is None and url is None) or (file_path is not None and url is not None):
             logger.error("Invalid parameters: Exactly one of file_path or url must be provided")
             raise ValidationError("Exactly one of file_path or url must be provided")
+        _reject_reserved_extra_options(extra_options, _IMAGE_REQUEST_OPTION_KEYS)
         endpoint = urljoin(self.auth.api_url, 'v3/text')
         image_options: Dict[str, Any] = {
             "metadata": {
@@ -349,38 +347,8 @@ class MathpixClient:
             image_options["disable_itemize"] = disable_itemize
         if disable_lstlisting is not None:
             image_options["disable_lstlisting"] = disable_lstlisting
-        if include_chemistry is not None:
-            image_options["include_chemistry"] = include_chemistry
         if include_page_info is not None:
             image_options["include_page_info"] = include_page_info
-        if language_hint is not None:
-            image_options["language_hint"] = language_hint
-        if include_text_caption is not None:
-            image_options["include_text_caption"] = include_text_caption
-        if table_ocr_algorithm is not None:
-            image_options["table_ocr_algorithm"] = table_ocr_algorithm
-        if include_chart_data is not None:
-            image_options["include_chart_data"] = include_chart_data
-        if include_detection_map is not None:
-            image_options["include_detection_map"] = include_detection_map
-        if include_font_size is not None:
-            image_options["include_font_size"] = include_font_size
-        if force_lines is not None:
-            image_options["force_lines"] = force_lines
-        if include_stats is not None:
-            image_options["include_stats"] = include_stats
-        if include_times is not None:
-            image_options["include_times"] = include_times
-        if ocr is not None:
-            image_options["ocr"] = ocr
-        if skip_recrop is not None:
-            image_options["skip_recrop"] = skip_recrop
-        if format_options is not None:
-            image_options["format_options"] = format_options
-        if beam_size is not None:
-            image_options["beam_size"] = beam_size
-        if n_best is not None:
-            image_options["n_best"] = n_best
         if enable_document_layout is not None:
             image_options["enable_document_layout"] = enable_document_layout
         if not self.improve_mathpix:
@@ -468,15 +436,10 @@ class MathpixClient:
             mathpix_webhook_secret: Optional[str] = None,
             webhook_payload: Optional[Dict[str, Any]] = None,
             webhook_enabled_events: Optional[List[str]] = None,
-            tags: Optional[List[str]] = None,
             disable_itemize: Optional[bool] = None,
             disable_lstlisting: Optional[bool] = None,
-            include_chemistry: Optional[bool] = None,
             include_page_info: Optional[bool] = None,
             include_page_breaks: Optional[bool] = None,
-            language_hint: Optional[str] = None,
-            include_text_caption: Optional[bool] = None,
-            table_ocr_algorithm: Optional[str] = None,
             conversion_options: Optional[Dict[str, Any]] = None,
             extra_options: Optional[Dict[str, Any]] = None,
     ) -> Pdf:
@@ -486,7 +449,7 @@ class MathpixClient:
             file_path: Path to a local PDF file.
             url: URL of a remote PDF file.
             metadata: Optional dict to attach metadata to a request
-            alphabets_allowed: Optional dict to list alphabets allowed in the output (see https://docs.mathpix.com/#alphabetsallowed-object)
+            alphabets_allowed: Optional dict to list alphabets allowed in the output (see https://docs.mathpix.com/reference/shared-types#alphabetsallowed-object)
             rm_spaces: Optional boolean to determine whether extra white space is removed from equations in "latex_styled" and "text" formats
             rm_fonts: Optional boolean to determine whether font commands such as \mathbf and \mathrm are removed from equations in "latex_styled" and "text" formats
             idiomatic_eqn_arrays: Optional boolean to specify whether to use aligned, gathered, or cases instead of an array environment for a list of equations
@@ -520,17 +483,12 @@ class MathpixClient:
             mathpix_webhook_secret: Optional secret for webhook authentication. (Not yet enabled)
             webhook_payload: Optional custom payload to include in webhooks. (Not yet enabled)
             webhook_enabled_events: Optional list of events to trigger webhooks. (Not yet enabled)
-            tags: Optional list of strings which can be used to identify results using the /v3/ocr-results endpoint
             disable_itemize: Optional boolean to disable itemize/enumerate list environments, rendering list items as flat lines
             disable_lstlisting: Optional boolean to disable the lstlisting environment for code blocks
-            include_chemistry: Optional boolean to enable chemistry diagram OCR
             include_page_info: Optional boolean to include page info in the output
             include_page_breaks: Optional boolean to include page break markers in the output
-            language_hint: Optional string to hint the primary language of the document
-            include_text_caption: Optional boolean to include captions for figures and tables
-            table_ocr_algorithm: Optional string to select the table OCR algorithm
-            conversion_options: Optional dict of per-format conversion options (see https://docs.mathpix.com/#conversionoptions-object)
-            extra_options: Optional dict of raw request options merged into the request body, taking precedence over the other arguments. Escape hatch for API options this SDK version does not model yet; values are validated server-side
+            conversion_options: Optional dict of per-format conversion options (see https://docs.mathpix.com/reference/shared-types#conversion-options)
+            extra_options: Optional dict of unmodeled request options. Modeled request fields are rejected; values are validated server-side
 
         Returns:
             Pdf: A new Pdf instance
@@ -558,6 +516,7 @@ class MathpixClient:
         if (file_path is None and url is None) or (file_path is not None and url is not None):
             logger.error("Invalid parameters: Exactly one of file_path or url must be provided")
             raise ValidationError("Exactly one of file_path or url must be provided")
+        _reject_reserved_extra_options(extra_options, _PDF_REQUEST_OPTION_KEYS)
         if not self.improve_mathpix:
             logger.debug('improve_mathpix set to False on the client')
             improve_mathpix = False
@@ -610,24 +569,14 @@ class MathpixClient:
             options["enable_tables_fallback"] = enable_tables_fallback
         if fullwidth_punctuation:
             options["fullwidth_punctuation"] = fullwidth_punctuation
-        if tags is not None:
-            options["tags"] = tags
         if disable_itemize is not None:
             options["disable_itemize"] = disable_itemize
         if disable_lstlisting is not None:
             options["disable_lstlisting"] = disable_lstlisting
-        if include_chemistry is not None:
-            options["include_chemistry"] = include_chemistry
         if include_page_info is not None:
             options["include_page_info"] = include_page_info
         if include_page_breaks is not None:
             options["include_page_breaks"] = include_page_breaks
-        if language_hint is not None:
-            options["language_hint"] = language_hint
-        if include_text_caption is not None:
-            options["include_text_caption"] = include_text_caption
-        if table_ocr_algorithm is not None:
-            options["table_ocr_algorithm"] = table_ocr_algorithm
         if conversion_options is not None:
             options["conversion_options"] = conversion_options
         if file_batch_id:
@@ -831,8 +780,8 @@ class MathpixClient:
             convert_to_mmd_zip: Optional boolean to automatically convert your result to mmd.zip
             convert_to_pptx: Optional boolean to automatically convert your result to pptx
             convert_to_html_zip: Optional boolean to automatically convert your result to html.zip
-            conversion_options: Optional dict of per-format conversion options (see https://docs.mathpix.com/#conversionoptions-object)
-            extra_options: Optional dict of raw request options merged into the request body, taking precedence over the other arguments. Escape hatch for API options this SDK version does not model yet; values are validated server-side
+            conversion_options: Optional dict of per-format conversion options (see https://docs.mathpix.com/reference/shared-types#conversion-options)
+            extra_options: Optional dict of unmodeled request options. Modeled request fields are rejected; values are validated server-side
 
         Returns:
             Conversion: A new Conversion instance.
@@ -841,6 +790,7 @@ class MathpixClient:
             MathpixClientError: If the API request fails.
         """
         logger.debug("Starting new MMD conversion")
+        _reject_reserved_extra_options(extra_options, _CONVERSION_REQUEST_OPTION_KEYS)
         endpoint = urljoin(self.auth.api_url, 'v3/converter')
         options = {
             "mmd": mmd,

--- a/mpxpy/mathpix_client.py
+++ b/mpxpy/mathpix_client.py
@@ -208,7 +208,8 @@ class MathpixClient:
             format_options: Optional[Dict[str, Any]] = None,
             beam_size: Optional[int] = None,
             n_best: Optional[int] = None,
-            enable_document_layout: Optional[bool] = None
+            enable_document_layout: Optional[bool] = None,
+            extra_options: Optional[Dict[str, Any]] = None
     ):
         r"""Process an image either from a local file or remote URL.
 
@@ -266,6 +267,7 @@ class MathpixClient:
             beam_size: Optional int between 1 and 10 for the beam search width
             n_best: Optional int (<= beam_size) for the number of candidate results to return
             enable_document_layout: Optional boolean to enable document layout analysis for "text" output
+            extra_options: Optional dict of raw request options merged into the request body, taking precedence over the other arguments. Escape hatch for API options this SDK version does not model yet; values are validated server-side
 
         Returns:
             Image: A new Image instance.
@@ -386,6 +388,8 @@ class MathpixClient:
             image_options["metadata"]["improve_mathpix"] = False
         elif not improve_mathpix:
             image_options["metadata"]["improve_mathpix"] = False
+        if extra_options:
+            image_options.update(extra_options)
         data = {
             "options_json": json.dumps(image_options)
         }
@@ -474,6 +478,7 @@ class MathpixClient:
             include_text_caption: Optional[bool] = None,
             table_ocr_algorithm: Optional[str] = None,
             conversion_options: Optional[Dict[str, Any]] = None,
+            extra_options: Optional[Dict[str, Any]] = None,
     ) -> Pdf:
         r"""Uploads a PDF, document, or ebook from a local file or remote URL and optionally requests conversions.
 
@@ -525,6 +530,7 @@ class MathpixClient:
             include_text_caption: Optional boolean to include captions for figures and tables
             table_ocr_algorithm: Optional string to select the table OCR algorithm
             conversion_options: Optional dict of per-format conversion options (see https://docs.mathpix.com/#conversionoptions-object)
+            extra_options: Optional dict of raw request options merged into the request body, taking precedence over the other arguments. Escape hatch for API options this SDK version does not model yet; values are validated server-side
 
         Returns:
             Pdf: A new Pdf instance
@@ -654,6 +660,8 @@ class MathpixClient:
             options["conversion_formats"]['mmd.zip'] = True
         if convert_to_html_zip:
             options["conversion_formats"]['html.zip'] = True
+        if extra_options:
+            options.update(extra_options)
         data = {
             "options_json": json.dumps(options)
         }

--- a/tests/test_request_options_unit.py
+++ b/tests/test_request_options_unit.py
@@ -1,0 +1,112 @@
+"""Unit tests for v3 request option forwarding and conflict handling."""
+import json
+from unittest.mock import patch
+import pytest
+from mpxpy.errors import ValidationError
+from mpxpy.mathpix_client import MathpixClient
+
+
+@pytest.fixture
+def client() -> MathpixClient:
+    return MathpixClient(app_id='test-app', app_key='test-key')
+
+
+def test_image_new_sends_documented_and_extra_options(client: MathpixClient, tmp_path) -> None:
+    image_path = tmp_path / 'image.png'
+    image_path.write_bytes(b'image')
+    with patch('mpxpy.mathpix_client.post') as mock_post:
+        mock_post.return_value.json.return_value = {'request_id': 'image-1'}
+        client.image_new(
+            file_path=str(image_path),
+            disable_itemize=False,
+            disable_lstlisting=True,
+            include_page_info=False,
+            enable_document_layout=True,
+            extra_options={'future_image_option': 'enabled'},
+        )
+    options = json.loads(mock_post.call_args.kwargs['data']['options_json'])
+    assert {
+        key: options[key] for key in (
+            'disable_itemize', 'disable_lstlisting', 'include_page_info',
+            'enable_document_layout', 'future_image_option',
+        )
+    } == {
+        'disable_itemize': False,
+        'disable_lstlisting': True,
+        'include_page_info': False,
+        'enable_document_layout': True,
+        'future_image_option': 'enabled',
+    }
+
+
+def test_image_new_rejects_modeled_extra_options(client: MathpixClient) -> None:
+    for key in ('src', 'metadata', 'callback', 'disable_itemize'):
+        with pytest.raises(ValidationError):
+            client.image_new(url='https://example.com/image.png', extra_options={key: 'override'})
+
+
+def test_pdf_new_sends_documented_and_extra_options(client: MathpixClient, tmp_path) -> None:
+    pdf_path = tmp_path / 'document.pdf'
+    pdf_path.write_bytes(b'%PDF-1.4')
+    with patch('mpxpy.mathpix_client.post') as mock_post:
+        mock_post.return_value.json.return_value = {'pdf_id': 'pdf-1'}
+        client.pdf_new(
+            file_path=str(pdf_path),
+            disable_itemize=False,
+            disable_lstlisting=True,
+            include_page_info=True,
+            include_page_breaks=False,
+            conversion_options={'docx': {'font_size': 12}},
+            extra_options={'future_pdf_option': 'enabled'},
+        )
+    options = json.loads(mock_post.call_args.kwargs['data']['options_json'])
+    assert {
+        key: options[key] for key in (
+            'disable_itemize', 'disable_lstlisting', 'include_page_info',
+            'include_page_breaks', 'conversion_options', 'future_pdf_option',
+        )
+    } == {
+        'disable_itemize': False,
+        'disable_lstlisting': True,
+        'include_page_info': True,
+        'include_page_breaks': False,
+        'conversion_options': {'docx': {'font_size': 12}},
+        'future_pdf_option': 'enabled',
+    }
+
+
+def test_pdf_new_rejects_modeled_extra_options(client: MathpixClient) -> None:
+    for key in (
+            'url', 'metadata', 'conversion_formats', 'file_batch_id', 'webhook_url',
+            'mathpix_webhook_secret', 'webhook_payload', 'webhook_enabled_events',
+            'conversion_options',
+    ):
+        with pytest.raises(ValidationError):
+            client.pdf_new(url='https://example.com/document.pdf', extra_options={key: 'override'})
+
+
+def test_conversion_new_sends_documented_and_extra_options(client: MathpixClient) -> None:
+    with patch('mpxpy.mathpix_client.post') as mock_post:
+        mock_post.return_value.json.return_value = {'conversion_id': 'conversion-1'}
+        client.conversion_new(
+            mmd='# Document',
+            convert_to_docx=True,
+            conversion_options={'docx': {'font_size': 12}},
+            extra_options={'metadata': {'customer_id': 'customer-1'}},
+        )
+    assert mock_post.call_args.kwargs['json'] == {
+        'mmd': '# Document',
+        'formats': {'docx': True},
+        'conversion_options': {'docx': {'font_size': 12}},
+        'metadata': {'customer_id': 'customer-1'},
+    }
+
+
+def test_conversion_new_rejects_modeled_extra_options(client: MathpixClient) -> None:
+    for key in ('mmd', 'formats', 'conversion_options'):
+        with pytest.raises(ValidationError):
+            client.conversion_new(
+                mmd='# Document',
+                convert_to_docx=True,
+                extra_options={key: 'override'},
+            )


### PR DESCRIPTION
## What

Adds documented OCR and conversion options that were previously unreachable from the SDK:

- `image_new`: `disable_itemize`, `disable_lstlisting`, `include_page_info`, and `enable_document_layout`
- `pdf_new`: `disable_itemize`, `disable_lstlisting`, `include_page_info`, `include_page_breaks`, and `conversion_options`
- `conversion_new`: `conversion_options`

Each method also accepts `extra_options` as an escape hatch for API fields the SDK does not model yet. Modeled and structural request fields are reserved: conflicts raise `ValidationError` instead of silently replacing explicit arguments, sources, metadata, webhook configuration, or conversion inputs.

## Why

Triggered by customer request to send `disable_itemize` through `mpxpy`. The escape hatch prevents the next newly introduced API option from requiring an immediate SDK release while keeping the typed interface aligned with the documented endpoint contract.

## Testing

- `pytest -q tests/test_request_options_unit.py tests/test_files_api_unit.py` — 64 passed
- `python -m compileall -q mpxpy tests/test_request_options_unit.py`
- `python -m build` — sdist and wheel built successfully

The credentialed integration suites were not run because they submit billable OCR/PDF/conversion requests.