### PR TITLE
[mpxpy] Add Files API webhooks support

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,7 @@ Returns a new Pdf instance.
 - `convert_to_html_zip`: Optional boolean to automatically convert your result to html.zip
 - `improve_mathpix`: Optional boolean to enable Mathpix to retain user output. Default is true
 - `file_batch_id`: Optional batch ID to associate this file with.
+- `callback_url` / `callback_headers` / `callback_events`: Per-request webhook overrides for this submission (see [Webhooks](#webhooks)). `callback_url` overrides the account default; `callback_headers` are sent on that delivery (a per-request URL does not inherit the account-default headers); `callback_events` selects events (`file.completed`, `file.error`).
 
 ##### `MathpixClient.conversion_new`
 
@@ -452,6 +453,7 @@ Submit a single document for async processing, from a remote URI (`POST /files/v
 - `image_output_mode`: Set to `'local'` to write cropped images into `destination_uri` storage instead of the Mathpix CDN.
 - `include_page_info`: Include per-page information in the output.
 - `metadata`: Optional dict to attach metadata to the request.
+- `callback_url` / `callback_headers` / `callback_events`: Per-request webhook overrides for this submission (see [Webhooks](#webhooks)). `callback_url` overrides the account default; `callback_headers` are sent on that delivery (a per-request URL does not inherit the account-default headers); `callback_events` selects events (`file.completed`, `file.error`).
 - Plus the same OCR options as `pdf_new` (`alphabets_allowed`, `rm_spaces`, `include_smiles`, `math_inline_delimiters`, `page_ranges`, etc.).
 
 ##### `MathpixClient.file_job_new`
@@ -467,6 +469,7 @@ Submit a batch of documents in one call (the server enforces an items-per-call c
 - `image_output_mode`: Job-wide; `'local'` writes cropped images to each file's `destination_uri`.
 - `metadata`: Optional dict to attach metadata to the request.
 - `extra_options`: Additional request options dict merged into the request body — an escape hatch for API options this SDK version does not model yet (validated server-side). May not override the validated request fields.
+- `callback_url` / `callback_headers` / `callback_events`: Per-request webhook overrides for the job (see [Webhooks](#webhooks)). `callback_events` may include `file.completed`, `file.error`, and `job.completed` (the batch event, delivered once after the job is finalized).
 - Plus the same OCR options as `pdf_new`, applied to every file in the request.
 
 ##### `MathpixClient.file_job_list`
@@ -505,6 +508,7 @@ Returned by `file_job_new` and `file_job_get`. Methods:
 - `files(status=None, limit=None, paging_state=None)`: One page of the job's file listing, optionally filtered to `pending`, `completed`, or `error`.
 - `files_iter(status=None, limit=None)`: Iterate over all files, following pagination.
 - `file_by_custom_id(custom_id)`: Fetch one file by the `(job_id, custom_id)` you supplied at submission.
+- `finalize()`: Mark the job as finalized so no more files can be added; required to arm the `job.completed` webhook, which is delivered once after finalize and after every file reaches a terminal state (see [Webhooks](#webhooks)). Idempotent; returns the finalize response (`job_id`, `finalized_at`, `message`).
 
 ##### Data sources (cloud storage setup)
 
@@ -558,6 +562,8 @@ For AWS and Azure, call `DataSource.test()` afterward to verify the grant end-to
 #### Webhooks
 
 The Files API can call a webhook when processing finishes, instead of you polling. Set an account-default callback once, override it per request when needed, and verify the signature on every delivery.
+
+The events are `file.completed` and `file.error` for a single document (success and failure), and `job.completed` for a finalized batch (delivered once). `webhook_config_get()` returns a `WebhookConfig` with `.signing_secret`, `.callback_url`, `.callback_headers`, and `.callback_events`; the first call mints the signing secret.
 
 Set the account default (the first `webhook_config_get` mints the signing secret). `webhook_config_set` is a partial update: fields you pass are updated and fields you omit (leave as `None`) are preserved. (The API's PUT is a full replacement, so the SDK reads the current config and merges your changes over it.)
 

--- a/README.md
+++ b/README.md
@@ -555,6 +555,61 @@ For AWS and Azure, call `DataSource.test()` afterward to verify the grant end-to
 - `data_source_test(data_source_id)`: Runs the read/write probe; returns `{'result', 'checks', 'message'}` and does **not** raise on a failed probe — use it to diagnose grant issues after customer-side IAM changes.
 - `data_source_delete(data_source_id)`: Removes the registration; already-started work is not interrupted, and the bucket can be registered again later. Deleting the registration does not revoke access on the cloud side — remove the grant separately to revoke access.
 
+#### Webhooks
+
+The Files API can call a webhook when processing finishes, instead of you polling. Set an account-default callback once, override it per request when needed, and verify the signature on every delivery.
+
+Set the account default (the first `webhook_config_get` mints the signing secret):
+
+```python
+client.webhook_config_set(
+    default_callback_url="https://your-app.example.com/mathpix-webhook",
+    default_callback_headers={"Authorization": "Bearer your-token"},
+    default_callback_events=["file.completed", "job.completed"],
+)
+client.webhook_config_test()  # sends a test delivery; returns {'status': ..., 'response_code': ..., 'detail': ...}
+```
+
+Override the callback for a single submission:
+
+```python
+file = client.file_new(
+    source_uri="https://cdn.mathpix.com/examples/cs229-notes1.pdf",
+    conversion_formats={"docx": True},
+    callback_url="https://your-app.example.com/one-off-hook",
+)
+```
+
+For a batch job, the terminal `job.completed` event fires only after you finalize the job (once every file has been submitted):
+
+```python
+job = client.file_job_new(files=[...], job_id="contracts-2026-08")
+client.file_job_finalize("contracts-2026-08")  # or job.finalize()
+```
+
+Verify each delivery in your handler with the signing secret. Pass the exact raw request body (bytes), not the parsed JSON:
+
+```python
+from flask import Flask, request, abort
+from mpxpy.mathpix_client import MathpixClient
+from mpxpy.webhooks import verify_signature
+
+app = Flask(__name__)
+client = MathpixClient()
+signing_secret = client.webhook_config_get().signing_secret
+
+@app.route("/mathpix-webhook", methods=["POST"])
+def mathpix_webhook():
+    signature = request.headers.get("Mathpix-Signature", "")
+    if not verify_signature(signature, request.get_data(), signing_secret):
+        abort(400)
+    event = request.get_json()
+    # handle event...
+    return "", 200
+```
+
+`verify_signature` recomputes the HMAC-SHA256 over `"{t}.{raw_body}"` keyed by the signing secret and rejects deliveries whose timestamp is outside a replay window (300 seconds by default, configurable via `tolerance_seconds`). It returns `False` for any invalid or malformed input and never raises.
+
 ##### `MathpixClient.query_usage`
 
 Query API usage statistics.

--- a/README.md
+++ b/README.md
@@ -580,7 +580,12 @@ file = client.file_new(
 For a batch job, the terminal `job.completed` event fires only after you finalize the job (once every file has been submitted):
 
 ```python
-job = client.file_job_new(files=[...], job_id="contracts-2026-08")
+job = client.file_job_new(
+    files=[...],
+    job_id="contracts-2026-08",
+    callback_url="https://your-app.example.com/mathpix-webhook",
+    callback_events=["job.completed"],
+)
 job.finalize()  # or client.file_job_get("contracts-2026-08").finalize()
 ```
 

--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ Returns a new Pdf instance.
 - `convert_to_html_zip`: Optional boolean to automatically convert your result to html.zip
 - `improve_mathpix`: Optional boolean to enable Mathpix to retain user output. Default is true
 - `file_batch_id`: Optional batch ID to associate this file with.
-- `callback_url` / `callback_headers` / `callback_events`: Webhook callback for this submission (see [Webhooks](#webhooks)). `callback_url` is the URL to notify on completion; `callback_headers` are sent on that delivery (e.g. an auth token your endpoint checks); `callback_events` selects which events to deliver (see [Webhooks](#webhooks) for the event names).
+- `callback_url` / `callback_headers` / `callback_events`: Webhook callback for this submission (see [Webhooks](#webhooks)). `callback_url` is the HTTPS URL to notify on completion — a submission without one is not notified at all; `callback_headers` are sent on that delivery (e.g. an auth token your endpoint checks); `callback_events` selects which events to deliver, defaulting to `['file.completed', 'file.error']` for one document, with `[]` turning deliveries off for just this submission.
 
 ##### `MathpixClient.conversion_new`
 
@@ -453,7 +453,7 @@ Submit a single document for async processing, from a remote URI (`POST /files/v
 - `image_output_mode`: Set to `'local'` to write cropped images into `destination_uri` storage instead of the Mathpix CDN.
 - `include_page_info`: Include per-page information in the output.
 - `metadata`: Optional dict to attach metadata to the request.
-- `callback_url` / `callback_headers` / `callback_events`: Webhook callback for this submission (see [Webhooks](#webhooks)). `callback_url` is the URL to notify on completion; `callback_headers` are sent on that delivery (e.g. an auth token your endpoint checks); `callback_events` selects which events to deliver (see [Webhooks](#webhooks) for the event names).
+- `callback_url` / `callback_headers` / `callback_events`: Webhook callback for this submission (see [Webhooks](#webhooks)). `callback_url` is the HTTPS URL to notify on completion — a submission without one is not notified at all; `callback_headers` are sent on that delivery (e.g. an auth token your endpoint checks); `callback_events` selects which events to deliver. The default follows the submission's shape, which `job_id` decides: without a `job_id` the document defaults to `['file.completed', 'file.error']`, while a document submitted into a job is batch-shaped and defaults to `['job.completed']` only, delivered after the job is finalized — pass `callback_events` explicitly to get per-document events on a job member. `[]` turns deliveries off for just this submission.
 - Plus the same OCR options as `pdf_new` (`alphabets_allowed`, `rm_spaces`, `include_smiles`, `math_inline_delimiters`, `page_ranges`, etc.).
 
 ##### `MathpixClient.file_job_new`
@@ -469,7 +469,7 @@ Submit a batch of documents in one call (the server enforces an items-per-call c
 - `image_output_mode`: Job-wide; `'local'` writes cropped images to each file's `destination_uri`.
 - `metadata`: Optional dict to attach metadata to the request.
 - `extra_options`: Additional request options dict merged into the request body — an escape hatch for API options this SDK version does not model yet (validated server-side). May not override the validated request fields.
-- `callback_url` / `callback_headers` / `callback_events`: Per-request webhook settings for the job. With `callback_events` omitted, a job defaults to `job.completed` only (delivered once after the job is finalized); request the per-file `file.completed` / `file.error` events explicitly if you want them (see [Webhooks](#webhooks) for the event names).
+- `callback_url` / `callback_headers` / `callback_events`: Per-request webhook settings for the job. With `callback_events` omitted, a job defaults to `job.completed` only (delivered once after the job is finalized and every file has finished); request the per-file `file.completed` / `file.error` events explicitly if you want them, or pass `[]` to turn deliveries off for this batch (see [Webhooks](#webhooks) for the event names).
 - Plus the same OCR options as `pdf_new`, applied to every file in the request.
 
 ##### `MathpixClient.file_job_list`
@@ -508,7 +508,7 @@ Returned by `file_job_new` and `file_job_get`. Methods:
 - `files(status=None, limit=None, paging_state=None)`: One page of the job's file listing, optionally filtered to `pending`, `completed`, or `error`.
 - `files_iter(status=None, limit=None)`: Iterate over all files, following pagination.
 - `file_by_custom_id(custom_id)`: Fetch one file by the `(job_id, custom_id)` you supplied at submission.
-- `finalize()`: Mark the job as finalized so no more files can be added; required to arm the `job.completed` webhook, which is delivered once after finalize and after every file reaches a terminal state (see [Webhooks](#webhooks)). Idempotent; returns the finalize response (`job_id`, `finalized_at`, `message`).
+- `finalize()`: Mark the job as finalized so no more files can be added; required to arm the `job.completed` webhook, which is delivered once after finalize and after every file reaches a terminal state — a job that is never finalized never sends it (see [Webhooks](#webhooks)). Finalize whenever you are done submitting, before or after the files finish. Idempotent; returns the finalize response (`job_id`, `finalized_at`, `message`).
 
 ##### Data sources (cloud storage setup)
 
@@ -561,9 +561,11 @@ For AWS and Azure, call `DataSource.test()` afterward to verify the grant end-to
 
 ##### Webhooks
 
-The Files API can call a webhook when processing finishes, instead of you polling. Pass the callback on each submission and verify the signature on every delivery.
+The Files API can call a webhook when processing finishes, instead of you polling. Pass the callback on each submission and verify the signature on every delivery. Polling keeps working and stays the authoritative record: a missed delivery never loses a result.
 
-The event names are `file.completed` and `file.error` for a single document (success and failure), and `job.completed` for a finalized batch (delivered once). This is the canonical event list that the per-request `callback_events` on the submission methods above draw from.
+The event names are `file.completed` and `file.error` for a single document (success and failure), and `job.completed` for a finalized batch (delivered once). This is the canonical event list that the per-request `callback_events` on the submission methods above draw from. Without `callback_events`, the submission's shape decides, and `job_id` is what decides the shape: a document submitted without a `job_id` gets `file.completed` and `file.error`, while anything carrying a `job_id` — a batch, or a single `file_new` submitted into a job — gets `job.completed` only. An explicit `callback_events` decides alone, including `[]` as the off switch for that one submission.
+
+`file.completed` fires only once the document's OCR result and every conversion format the submission requested have settled, so a requested `docx` or `md` is downloadable the moment the delivery arrives; when the submission requested conversions the body carries a `formats` map with each format's own status. A conversion that fails does not turn the event into `file.error` — the OCR result is there, and the failed format shows up in `formats`.
 
 Set the callback per submission. Pass `callback_headers` if your endpoint needs auth (e.g. a bearer token you check on receipt), and `callback_events` to select which events to deliver:
 
@@ -610,11 +612,29 @@ def mathpix_webhook():
     return "", 200
 ```
 
-`verify_signature` recomputes the HMAC-SHA256 over `"{t}.{raw_body}"` keyed by the signing secret and rejects deliveries whose timestamp is outside a replay window (300 seconds by default, configurable via `tolerance_seconds`). A delivery header carries a single `v1` value today; `verify_signature` also accepts a header bearing multiple `v1` values (a match on any one verifies), so it keeps working if signature rotation is added later. It returns `False` for any invalid or malformed input (including an empty secret) and never raises.
+`verify_signature` recomputes the HMAC-SHA256 over `"{t}.{raw_body}"` keyed by the signing secret and rejects deliveries whose timestamp is outside a replay window (300 seconds by default, configurable via `tolerance_seconds`). The window is measured against your own machine's clock, so a handler whose clock is more than five minutes out rejects every delivery — keep it synchronized. A delivery header carries a single `v1` value today; `verify_signature` also accepts a header bearing multiple `v1` values (a match on any one verifies), so it keeps working if signature rotation is added later. `verify_signature` returns `False` for any invalid or malformed input (including an empty secret) and never raises.
+
+Delivery is at least once, so the same notification can arrive twice: deduplicate on `event` plus `file_id` (`event` plus `job_id` for `job.completed`), acknowledge with a 2xx as soon as you have durably accepted the delivery, and process afterward. A slow answer (over 10 seconds) counts as no answer and is retried; a client-error answer tells Mathpix the endpoint is misconfigured for that notification and stops its retries, so poll for anything missed.
 
 ##### `MathpixClient.webhook_config_get`
 
-Returns a `WebhookConfig` carrying `.signing_secret` for this app key. Each app key has its own signing secret, fetched with the same app key you submit under; the first call mints it. Use the secret to verify delivery signatures.
+Returns a `WebhookConfig` carrying your `.signing_secret`; the first call mints it. It is the only stored webhook setting — the destination, headers, and events are per-submission arguments.
+
+##### `MathpixClient.webhook_config_test`
+
+Sends one signed test delivery to a URL you name and returns the outcome synchronously, so you can verify a handler before any real document is involved:
+
+```python
+outcome = client.webhook_config_test(
+    callback_url="https://your-app.example.com/mathpix-webhook",
+    callback_headers={"Authorization": "Bearer your-token"},  # optional
+)
+# {'status': 'delivered', 'response_code': 200, 'detail': None}
+```
+
+- The sample is a `file.completed` body carrying the reserved diagnostic `file_id` `00000000-0000-0000-0000-000000000000`, which is never a real document, so your handler can recognize test deliveries structurally.
+- One attempt, no retries; up to 10 test deliveries per minute for your app.
+- An endpoint that refuses the test is not an error in this call: `status` is `'failed'` with the `response_code` your endpoint answered (`None` when no answer arrived) and a `detail` sentence. Only the request itself failing raises (e.g. a rejected `callback_url` or the rate limit).
 
 ##### `MathpixClient.query_usage`
 

--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ Returns a new Pdf instance.
 - `convert_to_html_zip`: Optional boolean to automatically convert your result to html.zip
 - `improve_mathpix`: Optional boolean to enable Mathpix to retain user output. Default is true
 - `file_batch_id`: Optional batch ID to associate this file with.
-- `callback_url` / `callback_headers` / `callback_events`: Per-request webhook overrides for this submission (see [Webhooks](#webhooks)). `callback_url` overrides the account default; `callback_headers` are sent on that delivery (a per-request URL does not inherit the account-default headers); `callback_events` selects which events to deliver (see [Webhooks](#webhooks) for the event names).
+- `callback_url` / `callback_headers` / `callback_events`: Webhook callback for this submission (see [Webhooks](#webhooks)). `callback_url` is the URL to notify on completion; `callback_headers` are sent on that delivery (e.g. an auth token your endpoint checks); `callback_events` selects which events to deliver (see [Webhooks](#webhooks) for the event names).
 
 ##### `MathpixClient.conversion_new`
 
@@ -453,7 +453,7 @@ Submit a single document for async processing, from a remote URI (`POST /files/v
 - `image_output_mode`: Set to `'local'` to write cropped images into `destination_uri` storage instead of the Mathpix CDN.
 - `include_page_info`: Include per-page information in the output.
 - `metadata`: Optional dict to attach metadata to the request.
-- `callback_url` / `callback_headers` / `callback_events`: Per-request webhook overrides for this submission (see [Webhooks](#webhooks)). `callback_url` overrides the account default; `callback_headers` are sent on that delivery (a per-request URL does not inherit the account-default headers); `callback_events` selects which events to deliver (see [Webhooks](#webhooks) for the event names).
+- `callback_url` / `callback_headers` / `callback_events`: Webhook callback for this submission (see [Webhooks](#webhooks)). `callback_url` is the URL to notify on completion; `callback_headers` are sent on that delivery (e.g. an auth token your endpoint checks); `callback_events` selects which events to deliver (see [Webhooks](#webhooks) for the event names).
 - Plus the same OCR options as `pdf_new` (`alphabets_allowed`, `rm_spaces`, `include_smiles`, `math_inline_delimiters`, `page_ranges`, etc.).
 
 ##### `MathpixClient.file_job_new`
@@ -561,29 +561,19 @@ For AWS and Azure, call `DataSource.test()` afterward to verify the grant end-to
 
 ##### Webhooks
 
-The Files API can call a webhook when processing finishes, instead of you polling. Set an account-default callback once, override it per request when needed, and verify the signature on every delivery.
+The Files API can call a webhook when processing finishes, instead of you polling. Pass the callback on each submission and verify the signature on every delivery.
 
-The event names are `file.completed` and `file.error` for a single document (success and failure), and `job.completed` for a finalized batch (delivered once). This is the canonical event list; the per-request `callback_events` on the submission methods above draw from it.
+The event names are `file.completed` and `file.error` for a single document (success and failure), and `job.completed` for a finalized batch (delivered once). This is the canonical event list that the per-request `callback_events` on the submission methods above draw from.
 
-Set the account default. `webhook_config_set` is a partial update: fields you pass are updated and fields you omit (leave as `None`) are preserved. (The API's PUT is a full replacement, so the SDK reads the current config and merges your changes over it.)
-
-```python
-client.webhook_config_set(
-    callback_url="https://your-app.example.com/mathpix-webhook",
-    callback_headers={"Authorization": "Bearer your-token"},
-    callback_events=["file.completed", "job.completed"],
-)
-client.webhook_config_test()  # sends a test delivery; returns {'status': ..., 'response_code': ..., 'detail': ...}
-```
-
-Override the callback for a single submission. A per-request `callback_url` does not inherit the account-default `callback_headers` (the server withholds account credentials from a per-request URL), so pass `callback_headers` too if the one-off endpoint needs auth:
+Set the callback per submission. Pass `callback_headers` if your endpoint needs auth (e.g. a bearer token you check on receipt), and `callback_events` to select which events to deliver:
 
 ```python
 file = client.file_new(
     source_uri="https://cdn.mathpix.com/examples/cs229-notes1.pdf",
     conversion_formats={"docx": True},
-    callback_url="https://your-app.example.com/one-off-hook",
-    callback_headers={"Authorization": "Bearer one-off-token"},
+    callback_url="https://your-app.example.com/mathpix-webhook",
+    callback_headers={"Authorization": "Bearer your-token"},
+    callback_events=["file.completed", "file.error"],
 )
 ```
 
@@ -619,21 +609,7 @@ def mathpix_webhook():
 
 ##### `MathpixClient.webhook_config_get`
 
-Returns the account-default `WebhookConfig` with `.signing_secret`, `.callback_url`, `.callback_headers`, and `.callback_events`. The first call mints the signing secret used to verify delivery signatures.
-
-##### `MathpixClient.webhook_config_set`
-
-Update the account-default webhook configuration; returns the updated `WebhookConfig`. Read-modify-write over the API's full-replacement PUT, so fields you omit are preserved.
-
-###### `MathpixClient.webhook_config_set` Arguments
-
-- `callback_url`: Account-default callback URL for deliveries. `None` preserves the current value.
-- `callback_headers`: Account-default headers (str→str) sent on deliveries. `None` preserves the current value.
-- `callback_events`: Non-empty list of default event names (see the event list above). `None` preserves the current value; an empty list is rejected.
-
-##### `MathpixClient.webhook_config_test`
-
-Sends a test delivery to the configured callback URL and returns the probe body (`status`, `response_code`, `detail`). Does not raise on a failed delivery; raises only if no callback URL is configured or the request itself fails.
+Returns a `WebhookConfig` carrying `.signing_secret` for your account. The first call mints the signing secret used to verify delivery signatures.
 
 ##### `MathpixClient.query_usage`
 

--- a/README.md
+++ b/README.md
@@ -559,24 +559,25 @@ For AWS and Azure, call `DataSource.test()` afterward to verify the grant end-to
 
 The Files API can call a webhook when processing finishes, instead of you polling. Set an account-default callback once, override it per request when needed, and verify the signature on every delivery.
 
-Set the account default (the first `webhook_config_get` mints the signing secret):
+Set the account default (the first `webhook_config_get` mints the signing secret). `webhook_config_set` is a partial update: fields you pass are updated and fields you omit (leave as `None`) are preserved. (The API's PUT is a full replacement, so the SDK reads the current config and merges your changes over it.)
 
 ```python
 client.webhook_config_set(
-    default_callback_url="https://your-app.example.com/mathpix-webhook",
-    default_callback_headers={"Authorization": "Bearer your-token"},
-    default_callback_events=["file.completed", "job.completed"],
+    callback_url="https://your-app.example.com/mathpix-webhook",
+    callback_headers={"Authorization": "Bearer your-token"},
+    callback_events=["file.completed", "job.completed"],
 )
 client.webhook_config_test()  # sends a test delivery; returns {'status': ..., 'response_code': ..., 'detail': ...}
 ```
 
-Override the callback for a single submission:
+Override the callback for a single submission. A per-request `callback_url` does not inherit the account-default `callback_headers` (the server withholds account credentials from a per-request URL), so pass `callback_headers` too if the one-off endpoint needs auth:
 
 ```python
 file = client.file_new(
     source_uri="https://cdn.mathpix.com/examples/cs229-notes1.pdf",
     conversion_formats={"docx": True},
     callback_url="https://your-app.example.com/one-off-hook",
+    callback_headers={"Authorization": "Bearer one-off-token"},
 )
 ```
 
@@ -584,7 +585,7 @@ For a batch job, the terminal `job.completed` event fires only after you finaliz
 
 ```python
 job = client.file_job_new(files=[...], job_id="contracts-2026-08")
-client.file_job_finalize("contracts-2026-08")  # or job.finalize()
+job.finalize()  # or client.file_job_get("contracts-2026-08").finalize()
 ```
 
 Verify each delivery in your handler with the signing secret. Pass the exact raw request body (bytes), not the parsed JSON:

--- a/README.md
+++ b/README.md
@@ -469,7 +469,7 @@ Submit a batch of documents in one call (the server enforces an items-per-call c
 - `image_output_mode`: Job-wide; `'local'` writes cropped images to each file's `destination_uri`.
 - `metadata`: Optional dict to attach metadata to the request.
 - `extra_options`: Additional request options dict merged into the request body — an escape hatch for API options this SDK version does not model yet (validated server-side). May not override the validated request fields.
-- `callback_url` / `callback_headers` / `callback_events`: Per-request webhook overrides for the job. `callback_events` may additionally include the batch `job.completed` event, delivered once after the job is finalized (see [Webhooks](#webhooks) for the event names).
+- `callback_url` / `callback_headers` / `callback_events`: Per-request webhook settings for the job. With `callback_events` omitted, a job defaults to `job.completed` only (delivered once after the job is finalized); request the per-file `file.completed` / `file.error` events explicitly if you want them (see [Webhooks](#webhooks) for the event names).
 - Plus the same OCR options as `pdf_new`, applied to every file in the request.
 
 ##### `MathpixClient.file_job_list`
@@ -610,11 +610,11 @@ def mathpix_webhook():
     return "", 200
 ```
 
-`verify_signature` recomputes the HMAC-SHA256 over `"{t}.{raw_body}"` keyed by the signing secret and rejects deliveries whose timestamp is outside a replay window (300 seconds by default, configurable via `tolerance_seconds`). A delivery header may carry more than one `v1` value during a secret rotation; a match on any one verifies. It returns `False` for any invalid or malformed input (including an empty secret) and never raises.
+`verify_signature` recomputes the HMAC-SHA256 over `"{t}.{raw_body}"` keyed by the signing secret and rejects deliveries whose timestamp is outside a replay window (300 seconds by default, configurable via `tolerance_seconds`). A delivery header carries a single `v1` value today; `verify_signature` also accepts a header bearing multiple `v1` values (a match on any one verifies), so it keeps working if signature rotation is added later. It returns `False` for any invalid or malformed input (including an empty secret) and never raises.
 
 ##### `MathpixClient.webhook_config_get`
 
-Returns a `WebhookConfig` carrying `.signing_secret` for your account. The first call mints the signing secret used to verify delivery signatures.
+Returns a `WebhookConfig` carrying `.signing_secret` for this app key. Each app key has its own signing secret, fetched with the same app key you submit under; the first call mints it. Use the secret to verify delivery signatures.
 
 ##### `MathpixClient.query_usage`
 

--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ Returns a new Pdf instance.
 - `convert_to_html_zip`: Optional boolean to automatically convert your result to html.zip
 - `improve_mathpix`: Optional boolean to enable Mathpix to retain user output. Default is true
 - `file_batch_id`: Optional batch ID to associate this file with.
-- `callback_url` / `callback_headers` / `callback_events`: Per-request webhook overrides for this submission (see [Webhooks](#webhooks)). `callback_url` overrides the account default; `callback_headers` are sent on that delivery (a per-request URL does not inherit the account-default headers); `callback_events` selects events (`file.completed`, `file.error`).
+- `callback_url` / `callback_headers` / `callback_events`: Per-request webhook overrides for this submission (see [Webhooks](#webhooks)). `callback_url` overrides the account default; `callback_headers` are sent on that delivery (a per-request URL does not inherit the account-default headers); `callback_events` selects which events to deliver (see [Webhooks](#webhooks) for the event names).
 
 ##### `MathpixClient.conversion_new`
 
@@ -453,7 +453,7 @@ Submit a single document for async processing, from a remote URI (`POST /files/v
 - `image_output_mode`: Set to `'local'` to write cropped images into `destination_uri` storage instead of the Mathpix CDN.
 - `include_page_info`: Include per-page information in the output.
 - `metadata`: Optional dict to attach metadata to the request.
-- `callback_url` / `callback_headers` / `callback_events`: Per-request webhook overrides for this submission (see [Webhooks](#webhooks)). `callback_url` overrides the account default; `callback_headers` are sent on that delivery (a per-request URL does not inherit the account-default headers); `callback_events` selects events (`file.completed`, `file.error`).
+- `callback_url` / `callback_headers` / `callback_events`: Per-request webhook overrides for this submission (see [Webhooks](#webhooks)). `callback_url` overrides the account default; `callback_headers` are sent on that delivery (a per-request URL does not inherit the account-default headers); `callback_events` selects which events to deliver (see [Webhooks](#webhooks) for the event names).
 - Plus the same OCR options as `pdf_new` (`alphabets_allowed`, `rm_spaces`, `include_smiles`, `math_inline_delimiters`, `page_ranges`, etc.).
 
 ##### `MathpixClient.file_job_new`
@@ -469,7 +469,7 @@ Submit a batch of documents in one call (the server enforces an items-per-call c
 - `image_output_mode`: Job-wide; `'local'` writes cropped images to each file's `destination_uri`.
 - `metadata`: Optional dict to attach metadata to the request.
 - `extra_options`: Additional request options dict merged into the request body — an escape hatch for API options this SDK version does not model yet (validated server-side). May not override the validated request fields.
-- `callback_url` / `callback_headers` / `callback_events`: Per-request webhook overrides for the job (see [Webhooks](#webhooks)). `callback_events` may include `file.completed`, `file.error`, and `job.completed` (the batch event, delivered once after the job is finalized).
+- `callback_url` / `callback_headers` / `callback_events`: Per-request webhook overrides for the job. `callback_events` may additionally include the batch `job.completed` event, delivered once after the job is finalized (see [Webhooks](#webhooks) for the event names).
 - Plus the same OCR options as `pdf_new`, applied to every file in the request.
 
 ##### `MathpixClient.file_job_list`
@@ -559,13 +559,13 @@ For AWS and Azure, call `DataSource.test()` afterward to verify the grant end-to
 - `data_source_test(data_source_id)`: Runs the read/write probe; returns `{'result', 'checks', 'message'}` and does **not** raise on a failed probe — use it to diagnose grant issues after customer-side IAM changes.
 - `data_source_delete(data_source_id)`: Removes the registration; already-started work is not interrupted, and the bucket can be registered again later. Deleting the registration does not revoke access on the cloud side — remove the grant separately to revoke access.
 
-#### Webhooks
+##### Webhooks
 
 The Files API can call a webhook when processing finishes, instead of you polling. Set an account-default callback once, override it per request when needed, and verify the signature on every delivery.
 
-The events are `file.completed` and `file.error` for a single document (success and failure), and `job.completed` for a finalized batch (delivered once). `webhook_config_get()` returns a `WebhookConfig` with `.signing_secret`, `.callback_url`, `.callback_headers`, and `.callback_events`; the first call mints the signing secret.
+The event names are `file.completed` and `file.error` for a single document (success and failure), and `job.completed` for a finalized batch (delivered once). This is the canonical event list; the per-request `callback_events` on the submission methods above draw from it.
 
-Set the account default (the first `webhook_config_get` mints the signing secret). `webhook_config_set` is a partial update: fields you pass are updated and fields you omit (leave as `None`) are preserved. (The API's PUT is a full replacement, so the SDK reads the current config and merges your changes over it.)
+Set the account default. `webhook_config_set` is a partial update: fields you pass are updated and fields you omit (leave as `None`) are preserved. (The API's PUT is a full replacement, so the SDK reads the current config and merges your changes over it.)
 
 ```python
 client.webhook_config_set(
@@ -615,7 +615,25 @@ def mathpix_webhook():
     return "", 200
 ```
 
-`verify_signature` recomputes the HMAC-SHA256 over `"{t}.{raw_body}"` keyed by the signing secret and rejects deliveries whose timestamp is outside a replay window (300 seconds by default, configurable via `tolerance_seconds`). It returns `False` for any invalid or malformed input and never raises.
+`verify_signature` recomputes the HMAC-SHA256 over `"{t}.{raw_body}"` keyed by the signing secret and rejects deliveries whose timestamp is outside a replay window (300 seconds by default, configurable via `tolerance_seconds`). A delivery header may carry more than one `v1` value during a secret rotation; a match on any one verifies. It returns `False` for any invalid or malformed input (including an empty secret) and never raises.
+
+##### `MathpixClient.webhook_config_get`
+
+Returns the account-default `WebhookConfig` with `.signing_secret`, `.callback_url`, `.callback_headers`, and `.callback_events`. The first call mints the signing secret used to verify delivery signatures.
+
+##### `MathpixClient.webhook_config_set`
+
+Update the account-default webhook configuration; returns the updated `WebhookConfig`. Read-modify-write over the API's full-replacement PUT, so fields you omit are preserved.
+
+###### `MathpixClient.webhook_config_set` Arguments
+
+- `callback_url`: Account-default callback URL for deliveries. `None` preserves the current value.
+- `callback_headers`: Account-default headers (str→str) sent on deliveries. `None` preserves the current value.
+- `callback_events`: Non-empty list of default event names (see the event list above). `None` preserves the current value; an empty list is rejected.
+
+##### `MathpixClient.webhook_config_test`
+
+Sends a test delivery to the configured callback URL and returns the probe body (`status`, `response_code`, `detail`). Does not raise on a failed delivery; raises only if no callback URL is configured or the request itself fails.
 
 ##### `MathpixClient.query_usage`
 

--- a/changelog.md
+++ b/changelog.md
@@ -3,9 +3,9 @@
 ## August 18, 2026
 
 - Add webhooks support
-  - `webhook_config_get`/`webhook_config_set`/`webhook_config_test` manage the account-default `callback_url`, `callback_headers`, and `callback_events` (the first get mints the signing secret); new `WebhookConfig` resource object. `webhook_config_set` is a partial update: fields you pass are updated, fields you omit are preserved
-  - `callback_url`, `callback_headers`, and `callback_events` per-request params on `file_new`, `pdf_new`, and `file_job_new` override the account default (a per-request `callback_url` does not inherit the account-default headers)
+  - `callback_url`, `callback_headers`, and `callback_events` per-request params on `file_new`, `pdf_new`, and `file_job_new` register the webhook callback for that submission
   - `verify_signature` verifies the `Mathpix-Signature` header (HMAC-SHA256 over `"{t}.{raw_body}"`) with a replay window; exported from the package (`from mpxpy.webhooks import verify_signature`)
+  - `webhook_config_get` returns a `WebhookConfig` carrying your account's `signing_secret` (the first call mints it) for use with `verify_signature`
   - `FileJob.finalize()` finalizes a job so its terminal `job.completed` webhook can fire
   - Removed the never-enabled legacy `webhook_url`/`mathpix_webhook_secret`/`webhook_payload`/`webhook_enabled_events` params from `pdf_new`/`Pdf`
 

--- a/changelog.md
+++ b/changelog.md
@@ -5,7 +5,8 @@
 - Add webhooks support
   - `callback_url`, `callback_headers`, and `callback_events` per-request params on `file_new`, `pdf_new`, and `file_job_new` register the webhook callback for that submission
   - `verify_signature` verifies the `Mathpix-Signature` header (HMAC-SHA256 over `"{t}.{raw_body}"`) with a replay window; exported from the package (`from mpxpy.webhooks import verify_signature`)
-  - `webhook_config_get` returns a `WebhookConfig` carrying your account's `signing_secret` (the first call mints it) for use with `verify_signature`
+  - `webhook_config_get` returns a `WebhookConfig` carrying your `signing_secret` (the first call mints it) for use with `verify_signature`
+  - `webhook_config_test` sends one signed test delivery to a `callback_url` you name and returns the outcome (`status`, `response_code`, `detail`); a refused delivery is reported, not raised
   - `FileJob.finalize()` finalizes a job so its terminal `job.completed` webhook can fire
   - Removed the never-enabled legacy `webhook_url`/`mathpix_webhook_secret`/`webhook_payload`/`webhook_enabled_events` params from `pdf_new`/`Pdf`
 

--- a/changelog.md
+++ b/changelog.md
@@ -3,10 +3,10 @@
 ## August 18, 2026
 
 - Add webhooks support
-  - `webhook_config_get`/`webhook_config_set`/`webhook_config_test` manage the account-default callback URL, headers, and events (the first get mints the signing secret); new `WebhookConfig` resource object
-  - `callback_url`, `callback_headers`, and `callback_events` per-request params on `file_new`, `pdf_new`, and `file_job_new` override the account default
-  - `verify_signature` verifies the `Mathpix-Signature` header (HMAC-SHA256 over `"{t}.{raw_body}"`) with a replay window; exported from the package and available as `MathpixClient.verify_signature`
-  - `file_job_finalize(job_id)` (and `FileJob.finalize()`) finalize a job so its terminal `job.completed` webhook can fire
+  - `webhook_config_get`/`webhook_config_set`/`webhook_config_test` manage the account-default `callback_url`, `callback_headers`, and `callback_events` (the first get mints the signing secret); new `WebhookConfig` resource object. `webhook_config_set` is a partial update: fields you pass are updated, fields you omit are preserved
+  - `callback_url`, `callback_headers`, and `callback_events` per-request params on `file_new`, `pdf_new`, and `file_job_new` override the account default (a per-request `callback_url` does not inherit the account-default headers)
+  - `verify_signature` verifies the `Mathpix-Signature` header (HMAC-SHA256 over `"{t}.{raw_body}"`) with a replay window; exported from the package (`from mpxpy.webhooks import verify_signature`)
+  - `FileJob.finalize()` finalizes a job so its terminal `job.completed` webhook can fire
   - Removed the never-enabled legacy `webhook_url`/`mathpix_webhook_secret`/`webhook_payload`/`webhook_enabled_events` params from `pdf_new`/`Pdf`
 
 ## July 24, 2026

--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,7 @@
 
 - Add webhooks support
   - `webhook_config_get`/`webhook_config_set`/`webhook_config_test` manage the account-default callback URL, headers, and events (the first get mints the signing secret); new `WebhookConfig` resource object
-  - `callback_url`, `callback_headers`, and `callback_events` per-request params on `file_new`, `pdf_new`, `image_new`, `file_job_new`, and `scs_file_new` override the account default
+  - `callback_url`, `callback_headers`, and `callback_events` per-request params on `file_new`, `pdf_new`, and `file_job_new` override the account default
   - `verify_signature` verifies the `Mathpix-Signature` header (HMAC-SHA256 over `"{t}.{raw_body}"`) with a replay window; exported from the package and available as `MathpixClient.verify_signature`
   - `file_job_finalize(job_id)` (and `FileJob.finalize()`) finalize a job so its terminal `job.completed` webhook can fire
   - Removed the never-enabled legacy `webhook_url`/`mathpix_webhook_secret`/`webhook_payload`/`webhook_enabled_events` params from `pdf_new`/`Pdf`

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,14 @@
 # mpxpy changelog
 
+## August 18, 2026
+
+- Add webhooks support
+  - `webhook_config_get`/`webhook_config_set`/`webhook_config_test` manage the account-default callback URL, headers, and events (the first get mints the signing secret); new `WebhookConfig` resource object
+  - `callback_url`, `callback_headers`, and `callback_events` per-request params on `file_new`, `pdf_new`, `image_new`, `file_job_new`, and `scs_file_new` override the account default
+  - `verify_signature` verifies the `Mathpix-Signature` header (HMAC-SHA256 over `"{t}.{raw_body}"`) with a replay window; exported from the package and available as `MathpixClient.verify_signature`
+  - `file_job_finalize(job_id)` (and `FileJob.finalize()`) finalize a job so its terminal `job.completed` webhook can fire
+  - Removed the never-enabled legacy `webhook_url`/`mathpix_webhook_secret`/`webhook_payload`/`webhook_enabled_events` params from `pdf_new`/`Pdf`
+
 ## July 24, 2026
 
 - Add documented request options to `image_new`, `pdf_new`, and `conversion_new`, plus an `extra_options` escape hatch for unmodeled API fields that cannot override modeled request fields

--- a/mpxpy/__init__.py
+++ b/mpxpy/__init__.py
@@ -7,6 +7,7 @@ from mpxpy.pdf import Pdf
 from mpxpy.image import Image
 from mpxpy.conversion import Conversion
 from mpxpy.file_batch import FileBatch
+from mpxpy.webhooks import verify_signature, WebhookConfig
 from mpxpy.errors import (
     MathpixClientError,
     AuthenticationError,
@@ -27,6 +28,8 @@ __all__ = [
     "Image",
     "Conversion",
     "FileBatch",
+    "verify_signature",
+    "WebhookConfig",
     "MathpixClientError",
     "AuthenticationError",
     "ValidationError",

--- a/mpxpy/file_job.py
+++ b/mpxpy/file_job.py
@@ -6,7 +6,7 @@ import requests
 from mpxpy.auth import Auth
 from mpxpy.file import File
 from mpxpy.logger import logger
-from mpxpy.request_handler import get
+from mpxpy.request_handler import get, post
 from mpxpy.errors import ValidationError, error_from_response
 
 
@@ -242,6 +242,29 @@ class FileJob:
             request_options=self.request_options,
             status_result=result,
         )
+
+    def finalize(self) -> Dict[str, Any]:
+        """Finalize the job so its terminal 'job.completed' webhook can fire.
+
+        Performs POST /files/v1/jobs/{job_id}/finalize. Finalizing marks the job
+        as closed to new submissions; once every submitted file reaches a
+        terminal state the 'job.completed' event is delivered to the configured
+        callback. The call is idempotent: a second finalize keeps the original
+        finalized_at.
+
+        Returns:
+            dict: Response containing 'job_id', 'finalized_at', and 'message'.
+
+        Raises:
+            FilesApiError: If the job does not exist ('not_found').
+        """
+        logger.debug(f"Finalizing job {self.job_id}")
+        endpoint: str = urljoin(self.auth.files_api_url, f'/files/v1/jobs/{quote(self.job_id, safe="")}/finalize')
+        response: requests.Response = post(endpoint, headers=self.auth.headers, **self.request_options)
+        has_failed: bool = not response.ok
+        if has_failed:
+            raise error_from_response(response)
+        return response.json()
 
 
 def normalize_file_submission(item: Union[FileSubmission, Dict[str, Any]]) -> Dict[str, Any]:

--- a/mpxpy/file_job.py
+++ b/mpxpy/file_job.py
@@ -246,10 +246,17 @@ class FileJob:
     def finalize(self) -> Dict[str, Any]:
         """Finalize the job so its terminal 'job.completed' webhook can fire.
 
-        Performs POST /files/v1/jobs/{job_id}/finalize. Finalizing marks the job
-        as closed to new submissions; once every submitted file reaches a
-        terminal state the 'job.completed' event is delivered to the configured
-        callback. The call is idempotent: a second finalize keeps the original
+        Performs POST /files/v1/jobs/{job_id}/finalize. A job_id is yours to
+        choose, so any later request naming the same job appends to it, and
+        Mathpix cannot tell a finished batch from one whose next request has not
+        arrived: finalizing is what says the batch is complete. Once every
+        submitted file reaches a terminal state, the 'job.completed' event is
+        delivered to the callback_url the batch was submitted with. A job that
+        is never finalized never sends 'job.completed'; its files' own
+        'file.completed' and 'file.error' deliveries are unaffected.
+
+        Finalize whenever you are done submitting, before or after the files
+        finish. The call is idempotent: a second finalize keeps the original
         finalized_at.
 
         Returns:

--- a/mpxpy/mathpix_client.py
+++ b/mpxpy/mathpix_client.py
@@ -88,6 +88,25 @@ def _apply_processing_options(
         options["fullwidth_punctuation"] = fullwidth_punctuation
 
 
+def _apply_callback_options(
+        target: Dict[str, Any],
+        callback_url: Optional[str] = None,
+        callback_headers: Optional[Dict[str, str]] = None,
+        callback_events: Optional[List[str]] = None,
+) -> None:
+    """Add the per-request webhook callback fields to a request body dict.
+
+    Only fields the caller set are added, matching the request shape used across
+    the client's submission methods.
+    """
+    if callback_url is not None:
+        target["callback_url"] = callback_url
+    if callback_headers is not None:
+        target["callback_headers"] = callback_headers
+    if callback_events is not None:
+        target["callback_events"] = callback_events
+
+
 def _redact_uri(uri: Optional[str]) -> str:
     """Reduce a URI to its scheme and host for logging.
 
@@ -573,12 +592,7 @@ class MathpixClient:
             options["conversion_options"] = conversion_options
         if file_batch_id:
             options["file_batch_id"] = file_batch_id
-        if callback_url is not None:
-            options["callback_url"] = callback_url
-        if callback_headers is not None:
-            options["callback_headers"] = callback_headers
-        if callback_events is not None:
-            options["callback_events"] = callback_events
+        _apply_callback_options(options, callback_url, callback_headers, callback_events)
         if convert_to_docx:
             options["conversion_formats"]['docx'] = True
         if convert_to_md:
@@ -1043,12 +1057,7 @@ class MathpixClient:
             options["custom_id"] = custom_id
         if job_id:
             options["job_id"] = job_id
-        if callback_url is not None:
-            options["callback_url"] = callback_url
-        if callback_headers is not None:
-            options["callback_headers"] = callback_headers
-        if callback_events is not None:
-            options["callback_events"] = callback_events
+        _apply_callback_options(options, callback_url, callback_headers, callback_events)
         _apply_processing_options(
             options,
             alphabets_allowed=alphabets_allowed,
@@ -1147,12 +1156,7 @@ class MathpixClient:
             options["image_output_mode"] = image_output_mode
         if include_page_info is not None:
             options["include_page_info"] = include_page_info
-        if callback_url is not None:
-            options["callback_url"] = callback_url
-        if callback_headers is not None:
-            options["callback_headers"] = callback_headers
-        if callback_events is not None:
-            options["callback_events"] = callback_events
+        _apply_callback_options(options, callback_url, callback_headers, callback_events)
         _apply_processing_options(
             options,
             alphabets_allowed=alphabets_allowed,
@@ -1352,12 +1356,7 @@ class MathpixClient:
             body["conversion_formats"] = conversion_formats
         if image_output_mode:
             body["image_output_mode"] = image_output_mode
-        if callback_url is not None:
-            body["callback_url"] = callback_url
-        if callback_headers is not None:
-            body["callback_headers"] = callback_headers
-        if callback_events is not None:
-            body["callback_events"] = callback_events
+        _apply_callback_options(body, callback_url, callback_headers, callback_events)
         _apply_processing_options(
             body,
             alphabets_allowed=alphabets_allowed,
@@ -1569,11 +1568,12 @@ class MathpixClient:
         # The API's PUT is a full replacement, so read the current config and overlay only the
         # fields the caller provided; fields left as None are preserved (read-modify-write).
         current: WebhookConfig = self.webhook_config_get()
-        body: Dict[str, Any] = {
-            "default_callback_url": callback_url if callback_url is not None else current.callback_url,
-            "default_callback_headers": callback_headers if callback_headers is not None else current.callback_headers,
-            "default_callback_events": callback_events if callback_events is not None else current.callback_events,
-        }
+        merged: WebhookConfig = WebhookConfig.from_callback_values(
+            callback_url=callback_url if callback_url is not None else current.callback_url,
+            callback_headers=callback_headers if callback_headers is not None else current.callback_headers,
+            callback_events=callback_events if callback_events is not None else current.callback_events,
+        )
+        body: Dict[str, Any] = merged.to_request_body()
         logger.debug("Setting webhook config")
         endpoint: str = urljoin(self.auth.files_api_url, '/files/v1/webhook-config')
         try:

--- a/mpxpy/mathpix_client.py
+++ b/mpxpy/mathpix_client.py
@@ -20,7 +20,7 @@ from mpxpy.batch import Batch
 from mpxpy.auth import Auth
 from mpxpy.logger import logger, configure_logging
 from mpxpy.errors import MathpixClientError, ValidationError, error_from_response
-from mpxpy.request_handler import post, get, put
+from mpxpy.request_handler import post, get
 from mpxpy.webhooks import WebhookConfig
 
 
@@ -498,8 +498,8 @@ class MathpixClient:
             convert_to_html_zip: Optional boolean to automatically convert your result to html.zip
             improve_mathpix: Optional boolean to enable Mathpix to retain user output. Default is true
             file_batch_id: Optional batch ID to associate this file with.
-            callback_url: Optional URL to receive a webhook when processing completes. Overrides the account-default callback URL for this request
-            callback_headers: Optional dict of headers to include on the webhook delivery for this request. A per-request callback_url does NOT inherit the account-default callback_headers (the server deliberately withholds account credentials from a per-request URL), so if you pass callback_url and need auth headers on it you must also pass callback_headers. callback_events overrides independently
+            callback_url: Optional URL to receive a webhook when processing completes
+            callback_headers: Optional dict of headers to include on the webhook delivery (e.g. an auth token your endpoint checks)
             callback_events: Optional list of event names to subscribe to for this request
             disable_itemize: Optional boolean to disable itemize/enumerate list environments, rendering list items as flat lines
             disable_lstlisting: Optional boolean to disable the lstlisting environment for code blocks
@@ -954,15 +954,9 @@ class MathpixClient:
             enable_tables_fallback: Enable advanced table processing (default False).
             fullwidth_punctuation: Use fullwidth Unicode punctuation (default None).
             callback_url: Optional URL to receive a webhook when processing
-                completes. Overrides the account-default callback URL set via
-                webhook_config_set for this request.
+                completes.
             callback_headers: Optional dict of headers to include on the webhook
-                delivery for this request. A per-request callback_url does NOT
-                inherit the account-default callback_headers (the server
-                deliberately withholds account credentials from a per-request
-                URL), so if you pass callback_url and need auth headers on it you
-                must also pass callback_headers. callback_events overrides
-                independently.
+                delivery (e.g. an auth token your endpoint checks).
             callback_events: Optional list of event names to subscribe to for
                 this request.
 
@@ -1294,13 +1288,9 @@ class MathpixClient:
             enable_tables_fallback: Enable advanced table processing (default False).
             fullwidth_punctuation: Use fullwidth Unicode punctuation (default None).
             callback_url: Optional URL to receive a webhook when the job's files
-                complete. Job-wide; overrides the account-default callback URL.
+                complete. Job-wide.
             callback_headers: Optional dict of headers to include on the webhook
-                delivery. Job-wide. A per-request callback_url does NOT inherit
-                the account-default callback_headers (the server deliberately
-                withholds account credentials from a per-request URL), so if you
-                pass callback_url and need auth headers on it you must also pass
-                callback_headers. callback_events overrides independently.
+                delivery (e.g. an auth token your endpoint checks). Job-wide.
             callback_events: Optional list of event names to subscribe to.
                 Job-wide.
 
@@ -1504,15 +1494,15 @@ class MathpixClient:
         return job
 
     def webhook_config_get(self) -> WebhookConfig:
-        """Get the account-default webhook configuration.
+        """Get the webhook signing secret for your account.
 
         Performs GET /files/v1/webhook-config. The first call mints the signing
         secret used to verify webhook delivery signatures (see
-        mpxpy.webhooks.verify_signature). Subsequent calls return the same
-        secret along with the account-default callback target.
+        mpxpy.webhooks.verify_signature); subsequent calls return the same
+        secret.
 
         Returns:
-            WebhookConfig: The current webhook configuration.
+            WebhookConfig: Carries the signing_secret for your account.
 
         Raises:
             FilesApiError: If the request fails with a Files API error body.
@@ -1528,91 +1518,6 @@ class MathpixClient:
             return WebhookConfig(response.json())
         except requests.exceptions.RequestException as e:
             raise MathpixClientError(f"Mathpix webhook config request failed: {e}")
-
-    def webhook_config_set(
-            self,
-            callback_url: Optional[str] = None,
-            callback_headers: Optional[Dict[str, str]] = None,
-            callback_events: Optional[List[str]] = None,
-    ) -> WebhookConfig:
-        """Update the account-default webhook configuration.
-
-        Fields you pass are updated; fields you leave as None are preserved. The
-        Files API's PUT /files/v1/webhook-config is a full replacement, so this
-        method does a read-modify-write: it reads the current config, overlays
-        the fields you provided, and writes the merged whole. Submissions that do
-        not pass their own callback_url fall back to the account-default set here.
-
-        The bare callback_* arguments map onto the wire keys
-        default_callback_url/headers/events in the request body.
-
-        Args:
-            callback_url: New account-default callback URL. None preserves the
-                current value.
-            callback_headers: New account-default headers (str->str) sent on
-                deliveries. None preserves the current value.
-            callback_events: New non-empty list of default event names. None
-                preserves the current value; an empty list is rejected.
-
-        Returns:
-            WebhookConfig: The updated webhook configuration.
-
-        Raises:
-            ValidationError: If callback_events is an empty list.
-            FilesApiError: If the request fails with a Files API error body.
-            MathpixClientError: If the request fails without a Files API error body.
-        """
-        has_empty_events: bool = callback_events is not None and not callback_events
-        if has_empty_events:
-            raise ValidationError("callback_events must be a non-empty list")
-        # The API's PUT is a full replacement, so read the current config and overlay only the
-        # fields the caller provided; fields left as None are preserved (read-modify-write).
-        current: WebhookConfig = self.webhook_config_get()
-        merged: WebhookConfig = WebhookConfig.from_callback_values(
-            callback_url=callback_url if callback_url is not None else current.callback_url,
-            callback_headers=callback_headers if callback_headers is not None else current.callback_headers,
-            callback_events=callback_events if callback_events is not None else current.callback_events,
-        )
-        body: Dict[str, Any] = merged.to_request_body()
-        logger.debug("Setting webhook config")
-        endpoint: str = urljoin(self.auth.files_api_url, '/files/v1/webhook-config')
-        try:
-            response: requests.Response = put(endpoint, json=body, headers=self.auth.headers, **self.request_options)
-            has_failed: bool = not response.ok
-            if has_failed:
-                raise error_from_response(response)
-            return WebhookConfig(response.json())
-        except requests.exceptions.RequestException as e:
-            raise MathpixClientError(f"Mathpix webhook config request failed: {e}")
-
-    def webhook_config_test(self) -> Dict[str, Any]:
-        """Send a test webhook to the configured default callback URL.
-
-        Performs POST /files/v1/webhook-config/test. The API returns HTTP 200
-        for both a delivered and a failed probe; this method returns the probe
-        body as-is and does NOT raise on a failed delivery (mirroring
-        data_source_test). It raises only if no default callback URL is
-        configured or the request itself fails.
-
-        Returns:
-            dict: The probe body, containing 'status' ('delivered' or 'failed'),
-                'response_code' (int or None), and 'detail'.
-
-        Raises:
-            FilesApiError: If the request itself fails (e.g. no default callback
-                URL configured).
-            MathpixClientError: If the request fails without a Files API error body.
-        """
-        logger.debug("Testing webhook config")
-        endpoint: str = urljoin(self.auth.files_api_url, '/files/v1/webhook-config/test')
-        try:
-            response: requests.Response = post(endpoint, headers=self.auth.headers, **self.request_options)
-            has_failed: bool = not response.ok
-            if has_failed:
-                raise error_from_response(response)
-            return response.json()
-        except requests.exceptions.RequestException as e:
-            raise MathpixClientError(f"Mathpix webhook config test request failed: {e}")
 
     def onboarding_identities(self) -> Dict[str, Any]:
         """Get the Mathpix identities you grant cloud storage access to.

--- a/mpxpy/mathpix_client.py
+++ b/mpxpy/mathpix_client.py
@@ -21,7 +21,7 @@ from mpxpy.auth import Auth
 from mpxpy.logger import logger, configure_logging
 from mpxpy.errors import MathpixClientError, ValidationError, error_from_response
 from mpxpy.request_handler import post, get, put
-from mpxpy.webhooks import WebhookConfig, verify_signature as _verify_signature
+from mpxpy.webhooks import WebhookConfig
 
 
 def _apply_processing_options(
@@ -480,7 +480,7 @@ class MathpixClient:
             improve_mathpix: Optional boolean to enable Mathpix to retain user output. Default is true
             file_batch_id: Optional batch ID to associate this file with.
             callback_url: Optional URL to receive a webhook when processing completes. Overrides the account-default callback URL for this request
-            callback_headers: Optional dict of headers to include on the webhook delivery for this request
+            callback_headers: Optional dict of headers to include on the webhook delivery for this request. A per-request callback_url does NOT inherit the account-default callback_headers (the server deliberately withholds account credentials from a per-request URL), so if you pass callback_url and need auth headers on it you must also pass callback_headers. callback_events overrides independently
             callback_events: Optional list of event names to subscribe to for this request
             disable_itemize: Optional boolean to disable itemize/enumerate list environments, rendering list items as flat lines
             disable_lstlisting: Optional boolean to disable the lstlisting environment for code blocks
@@ -943,7 +943,12 @@ class MathpixClient:
                 completes. Overrides the account-default callback URL set via
                 webhook_config_set for this request.
             callback_headers: Optional dict of headers to include on the webhook
-                delivery for this request.
+                delivery for this request. A per-request callback_url does NOT
+                inherit the account-default callback_headers (the server
+                deliberately withholds account credentials from a per-request
+                URL), so if you pass callback_url and need auth headers on it you
+                must also pass callback_headers. callback_events overrides
+                independently.
             callback_events: Optional list of event names to subscribe to for
                 this request.
 
@@ -961,7 +966,11 @@ class MathpixClient:
         has_exactly_one_source: bool = sum(x is not None for x in [source_uri, file_path]) == 1
         if not has_exactly_one_source:
             raise ValidationError("Exactly one of source_uri or file_path must be provided")
-        _reject_reserved_extra_options(extra_options, {'source_uri', 'job_id', 'custom_id', 'metadata'})
+        _reject_reserved_extra_options(
+            extra_options,
+            {'source_uri', 'job_id', 'custom_id', 'metadata',
+             'callback_url', 'callback_headers', 'callback_events'},
+        )
         has_custom_id: bool = custom_id is not None
         if has_custom_id:
             has_job_id: bool = job_id is not None
@@ -1283,7 +1292,11 @@ class MathpixClient:
             callback_url: Optional URL to receive a webhook when the job's files
                 complete. Job-wide; overrides the account-default callback URL.
             callback_headers: Optional dict of headers to include on the webhook
-                delivery. Job-wide.
+                delivery. Job-wide. A per-request callback_url does NOT inherit
+                the account-default callback_headers (the server deliberately
+                withholds account credentials from a per-request URL), so if you
+                pass callback_url and need auth headers on it you must also pass
+                callback_headers. callback_events overrides independently.
             callback_events: Optional list of event names to subscribe to.
                 Job-wide.
 
@@ -1304,7 +1317,11 @@ class MathpixClient:
         has_files: bool = bool(files)
         if not has_files:
             raise ValidationError("files must be a non-empty list")
-        _reject_reserved_extra_options(extra_options, {'files', 'job_id', 'metadata'})
+        _reject_reserved_extra_options(
+            extra_options,
+            {'files', 'job_id', 'metadata',
+             'callback_url', 'callback_headers', 'callback_events'},
+        )
         normalized: List[Dict[str, Any]] = [normalize_file_submission(item) for item in files]
         has_explicit_job_id: bool = job_id is not None
         seen_custom_ids: Set[str] = set()
@@ -1487,36 +1504,6 @@ class MathpixClient:
         job.file_count = job_status.get('file_count')
         return job
 
-    def file_job_finalize(self, job_id: str) -> Dict[str, Any]:
-        """Finalize a job so its terminal 'job.completed' webhook can fire.
-
-        Performs POST /files/v1/jobs/{job_id}/finalize. Finalizing marks the job
-        as closed to new submissions; once every submitted file reaches a
-        terminal state the 'job.completed' event is delivered to the configured
-        callback. The call is idempotent: a second finalize keeps the original
-        finalized_at.
-
-        Args:
-            job_id: The job's identifier.
-
-        Returns:
-            dict: Response containing 'job_id', 'finalized_at', and 'message'.
-
-        Raises:
-            FilesApiError: If the job does not exist ('not_found').
-            MathpixClientError: If the request fails without a Files API error body.
-        """
-        logger.debug(f"Finalizing job {job_id}")
-        endpoint: str = urljoin(self.auth.files_api_url, f'/files/v1/jobs/{job_id}/finalize')
-        try:
-            response: requests.Response = post(endpoint, headers=self.auth.headers, **self.request_options)
-            has_failed: bool = not response.ok
-            if has_failed:
-                raise error_from_response(response)
-            return response.json()
-        except requests.exceptions.RequestException as e:
-            raise MathpixClientError(f"Mathpix Files API finalize request failed: {e}")
-
     def webhook_config_get(self) -> WebhookConfig:
         """Get the account-default webhook configuration.
 
@@ -1545,42 +1532,48 @@ class MathpixClient:
 
     def webhook_config_set(
             self,
-            default_callback_url: Optional[str] = None,
-            default_callback_headers: Optional[Dict[str, str]] = None,
-            default_callback_events: Optional[List[str]] = None,
+            callback_url: Optional[str] = None,
+            callback_headers: Optional[Dict[str, str]] = None,
+            callback_events: Optional[List[str]] = None,
     ) -> WebhookConfig:
-        """Set the account-default webhook configuration.
+        """Update the account-default webhook configuration.
 
-        Performs PUT /files/v1/webhook-config. Only the fields you provide are
-        sent, so an omitted field is left unchanged. Submissions that do not
-        pass their own callback_url fall back to this account default.
+        Fields you pass are updated; fields you leave as None are preserved. The
+        Files API's PUT /files/v1/webhook-config is a full replacement, so this
+        method does a read-modify-write: it reads the current config, overlays
+        the fields you provided, and writes the merged whole. Submissions that do
+        not pass their own callback_url fall back to the account-default set here.
+
+        The bare callback_* arguments map onto the wire keys
+        default_callback_url/headers/events in the request body.
 
         Args:
-            default_callback_url: Account-default callback URL for webhook deliveries.
-            default_callback_headers: Account-default headers (str->str) to include
-                on webhook deliveries.
-            default_callback_events: Non-empty list of event names to subscribe
-                to by default. Omit to use the server defaults; an empty list is
-                rejected.
+            callback_url: New account-default callback URL. None preserves the
+                current value.
+            callback_headers: New account-default headers (str->str) sent on
+                deliveries. None preserves the current value.
+            callback_events: New non-empty list of default event names. None
+                preserves the current value; an empty list is rejected.
 
         Returns:
             WebhookConfig: The updated webhook configuration.
 
         Raises:
-            ValidationError: If default_callback_events is an empty list.
+            ValidationError: If callback_events is an empty list.
             FilesApiError: If the request fails with a Files API error body.
             MathpixClientError: If the request fails without a Files API error body.
         """
-        body: Dict[str, Any] = {}
-        if default_callback_url is not None:
-            body["default_callback_url"] = default_callback_url
-        if default_callback_headers is not None:
-            body["default_callback_headers"] = default_callback_headers
-        if default_callback_events is not None:
-            has_events: bool = bool(default_callback_events)
-            if not has_events:
-                raise ValidationError("default_callback_events must be a non-empty list; omit it to use the defaults")
-            body["default_callback_events"] = default_callback_events
+        has_empty_events: bool = callback_events is not None and not callback_events
+        if has_empty_events:
+            raise ValidationError("callback_events must be a non-empty list")
+        # The API's PUT is a full replacement, so read the current config and overlay only the
+        # fields the caller provided; fields left as None are preserved (read-modify-write).
+        current: WebhookConfig = self.webhook_config_get()
+        body: Dict[str, Any] = {
+            "default_callback_url": callback_url if callback_url is not None else current.callback_url,
+            "default_callback_headers": callback_headers if callback_headers is not None else current.callback_headers,
+            "default_callback_events": callback_events if callback_events is not None else current.callback_events,
+        }
         logger.debug("Setting webhook config")
         endpoint: str = urljoin(self.auth.files_api_url, '/files/v1/webhook-config')
         try:
@@ -1598,7 +1591,7 @@ class MathpixClient:
         Performs POST /files/v1/webhook-config/test. The API returns HTTP 200
         for both a delivered and a failed probe; this method returns the probe
         body as-is and does NOT raise on a failed delivery (mirroring
-        data_source_test). It raises only if no default_callback_url is
+        data_source_test). It raises only if no default callback URL is
         configured or the request itself fails.
 
         Returns:
@@ -1620,26 +1613,6 @@ class MathpixClient:
             return response.json()
         except requests.exceptions.RequestException as e:
             raise MathpixClientError(f"Mathpix webhook config test request failed: {e}")
-
-    @staticmethod
-    def verify_signature(
-            signature_header: str,
-            body: Union[bytes, str],
-            secret: str,
-            tolerance_seconds: int = 300,
-    ) -> bool:
-        """Verify a Mathpix webhook signature.
-
-        Convenience delegate to mpxpy.webhooks.verify_signature. Recomputes the
-        HMAC-SHA256 over the raw request body and compares it, in constant time,
-        to the header's v1 value, rejecting deliveries outside the replay
-        window. See mpxpy.webhooks.verify_signature for the full scheme.
-
-        Returns:
-            bool: True if the signature is valid and within the replay window,
-                False for any invalid or malformed input. Never raises.
-        """
-        return _verify_signature(signature_header, body, secret, tolerance_seconds)
 
     def onboarding_identities(self) -> Dict[str, Any]:
         """Get the Mathpix identities you grant cloud storage access to.

--- a/mpxpy/mathpix_client.py
+++ b/mpxpy/mathpix_client.py
@@ -498,9 +498,9 @@ class MathpixClient:
             convert_to_html_zip: Optional boolean to automatically convert your result to html.zip
             improve_mathpix: Optional boolean to enable Mathpix to retain user output. Default is true
             file_batch_id: Optional batch ID to associate this file with.
-            callback_url: Optional URL to receive a webhook when processing completes
-            callback_headers: Optional dict of headers to include on the webhook delivery (e.g. an auth token your endpoint checks)
-            callback_events: Optional list of event names to subscribe to for this request
+            callback_url: Optional HTTPS URL to receive this request's webhook deliveries. A request without one is not notified at all
+            callback_headers: Optional dict of headers sent on this request's deliveries (e.g. an auth token your endpoint checks). Requires callback_url, which the API enforces: either callback field without it is a 400. At most 10 headers, 4 KB in total, and names Mathpix sets (Host, Content-Type, Content-Length, Transfer-Encoding, Connection, User-Agent, any Mathpix- name) are rejected
+            callback_events: Optional list of event names for this request. One document is one event, so this defaults to ['file.completed', 'file.error']; an empty list turns deliveries off for just this request, keeping callback_url in place
             disable_itemize: Optional boolean to disable itemize/enumerate list environments, rendering list items as flat lines
             disable_lstlisting: Optional boolean to disable the lstlisting environment for code blocks
             include_page_info: Optional boolean to include page info in the output
@@ -953,12 +953,25 @@ class MathpixClient:
             preserve_section_numbering: Keep existing section numbering (default True).
             enable_tables_fallback: Enable advanced table processing (default False).
             fullwidth_punctuation: Use fullwidth Unicode punctuation (default None).
-            callback_url: Optional URL to receive a webhook when processing
-                completes.
-            callback_headers: Optional dict of headers to include on the webhook
-                delivery (e.g. an auth token your endpoint checks).
-            callback_events: Optional list of event names to subscribe to for
-                this request.
+            callback_url: Optional HTTPS URL to receive this submission's
+                webhook deliveries. A submission without one is not notified at
+                all.
+            callback_headers: Optional dict of headers sent on this submission's
+                deliveries (e.g. an auth token your endpoint checks). Requires
+                callback_url, which the API enforces: either callback field
+                without it is a 400. At most 10 headers, 4 KB in total, and
+                names Mathpix sets (Host, Content-Type, Content-Length,
+                Transfer-Encoding, Connection, User-Agent, any Mathpix- name)
+                are rejected.
+            callback_events: Optional list of event names for this submission.
+                The default follows the submission's shape, which job_id
+                decides: without a job_id the document defaults to
+                ['file.completed', 'file.error'], while a document submitted
+                into a job is batch-shaped and defaults to ['job.completed']
+                only, delivered after the job is finalized. Pass this
+                explicitly to get per-document events on a job member. An empty
+                list turns deliveries off for just this submission, keeping
+                callback_url in place.
 
         Returns:
             File: A new File instance for polling status and downloading results.
@@ -1287,12 +1300,20 @@ class MathpixClient:
             preserve_section_numbering: Keep existing section numbering (default True).
             enable_tables_fallback: Enable advanced table processing (default False).
             fullwidth_punctuation: Use fullwidth Unicode punctuation (default None).
-            callback_url: Optional URL to receive a webhook when the job's files
-                complete. Job-wide.
-            callback_headers: Optional dict of headers to include on the webhook
-                delivery (e.g. an auth token your endpoint checks). Job-wide.
-            callback_events: Optional list of event names to subscribe to.
-                Job-wide.
+            callback_url: Optional HTTPS URL to receive this batch's webhook
+                deliveries. Job-wide; a batch without one is not notified at all.
+            callback_headers: Optional dict of headers sent on this batch's
+                deliveries (e.g. an auth token your endpoint checks). Job-wide,
+                and requires callback_url, which the API enforces: either
+                callback field without it is a 400. At most 10 headers, 4 KB in
+                total, and names Mathpix sets (Host, Content-Type,
+                Content-Length, Transfer-Encoding, Connection, User-Agent, any
+                Mathpix- name) are rejected.
+            callback_events: Optional list of event names for this batch.
+                Job-wide, and defaults to ['job.completed'], the single delivery
+                sent once the job is finalized and every file has finished; add
+                'file.completed' or 'file.error' for per-document deliveries, or
+                pass an empty list to turn deliveries off for this batch.
 
         Returns:
             FileJob: A new FileJob instance seeded with the response's job_id and
@@ -1494,15 +1515,17 @@ class MathpixClient:
         return job
 
     def webhook_config_get(self) -> WebhookConfig:
-        """Get this app key's webhook signing secret.
+        """Get your webhook signing secret.
 
         Performs GET /files/v1/webhook-config. The first call mints the signing
         secret used to verify webhook delivery signatures (see
         mpxpy.webhooks.verify_signature); subsequent calls return the same
-        secret.
+        secret. It is the only stored webhook setting: where a delivery goes,
+        what headers it carries, and which events fire are all per-submission
+        callback arguments.
 
         Returns:
-            WebhookConfig: Carries the signing_secret for this app key.
+            WebhookConfig: Carries your signing_secret.
 
         Raises:
             FilesApiError: If the request fails with a Files API error body.
@@ -1518,6 +1541,70 @@ class MathpixClient:
             return WebhookConfig(response.json())
         except requests.exceptions.RequestException as e:
             raise MathpixClientError(f"Mathpix webhook config request failed: {e}")
+
+    def webhook_config_test(
+            self,
+            callback_url: str,
+            callback_headers: Optional[Dict[str, str]] = None,
+    ) -> Dict[str, Any]:
+        """Send one signed test webhook delivery to a URL you name.
+
+        Performs POST /files/v1/webhook-config/test, which sends a single signed
+        sample delivery to callback_url and answers synchronously with the
+        outcome, before any real document is involved. Because the target is
+        named per call, an endpoint can be verified before any submission points
+        at it. The first call also mints the signing secret, like
+        webhook_config_get.
+
+        The sample is a 'file.completed' body carrying the reserved diagnostic
+        file_id '00000000-0000-0000-0000-000000000000', which is never a real
+        document, so a handler can recognize test deliveries structurally.
+
+        The test is a single attempt with no retries. Up to 10 test deliveries
+        per minute can be sent per app_key; beyond that the call fails with a
+        rate limit error until the next minute begins.
+
+        An endpoint that refuses the test is not an error in this call: the
+        probe body is returned as-is and a failed delivery does not raise, the
+        same way data_source_test reports a failed probe.
+
+        Args:
+            callback_url: The endpoint to send the test delivery to. The same
+                rules as callback_url at submission: HTTPS only, and URLs that
+                resolve to private or internal networks are rejected.
+            callback_headers: Optional dict of headers to send with the test, so
+                your endpoint's own authentication is verified too. The same
+                rules as callback_headers at submission.
+
+        Returns:
+            dict: The probe body: 'status' ('delivered' when your endpoint
+                accepted the delivery, 'failed' otherwise), 'response_code'
+                (the HTTP status your endpoint answered, or None when no answer
+                arrived), and 'detail' (a sentence saying what went wrong, or
+                None when the delivery succeeded).
+
+        Raises:
+            ValidationError: If callback_url is not a non-empty string.
+            FilesApiError: If the request itself fails with a Files API error
+                body (e.g. a rejected callback_url or a rate limit).
+            MathpixClientError: If the request fails without a Files API error body.
+        """
+        is_valid_callback_url: bool = isinstance(callback_url, str) and callback_url != ''
+        if not is_valid_callback_url:
+            raise ValidationError("callback_url must be a non-empty string")
+        logger.debug("Sending webhook test delivery")
+        endpoint: str = urljoin(self.auth.files_api_url, '/files/v1/webhook-config/test')
+        body: Dict[str, Any] = {"callback_url": callback_url}
+        if callback_headers is not None:
+            body["callback_headers"] = callback_headers
+        try:
+            response: requests.Response = post(endpoint, json=body, headers=self.auth.headers, **self.request_options)
+            has_failed: bool = not response.ok
+            if has_failed:
+                raise error_from_response(response)
+            return response.json()
+        except requests.exceptions.RequestException as e:
+            raise MathpixClientError(f"Mathpix webhook test request failed: {e}")
 
     def onboarding_identities(self) -> Dict[str, Any]:
         """Get the Mathpix identities you grant cloud storage access to.

--- a/mpxpy/mathpix_client.py
+++ b/mpxpy/mathpix_client.py
@@ -1494,7 +1494,7 @@ class MathpixClient:
         return job
 
     def webhook_config_get(self) -> WebhookConfig:
-        """Get the webhook signing secret for your account.
+        """Get this app key's webhook signing secret.
 
         Performs GET /files/v1/webhook-config. The first call mints the signing
         secret used to verify webhook delivery signatures (see
@@ -1502,7 +1502,7 @@ class MathpixClient:
         secret.
 
         Returns:
-            WebhookConfig: Carries the signing_secret for your account.
+            WebhookConfig: Carries the signing_secret for this app key.
 
         Raises:
             FilesApiError: If the request fails with a Files API error body.

--- a/mpxpy/mathpix_client.py
+++ b/mpxpy/mathpix_client.py
@@ -20,7 +20,8 @@ from mpxpy.batch import Batch
 from mpxpy.auth import Auth
 from mpxpy.logger import logger, configure_logging
 from mpxpy.errors import MathpixClientError, ValidationError, error_from_response
-from mpxpy.request_handler import post, get
+from mpxpy.request_handler import post, get, put
+from mpxpy.webhooks import WebhookConfig, verify_signature as _verify_signature
 
 
 def _apply_processing_options(
@@ -138,8 +139,8 @@ _PDF_REQUEST_OPTION_KEYS: Set[str] = {
     'include_diagram_text', 'numbers_default_to_math', 'math_inline_delimiters',
     'math_display_delimiters', 'page_ranges', 'enable_spell_check', 'auto_number_sections',
     'remove_section_numbering', 'preserve_section_numbering', 'enable_tables_fallback',
-    'fullwidth_punctuation', 'conversion_formats', 'file_batch_id', 'webhook_url',
-    'mathpix_webhook_secret', 'webhook_payload', 'webhook_enabled_events', 'disable_itemize',
+    'fullwidth_punctuation', 'conversion_formats', 'file_batch_id', 'callback_url',
+    'callback_headers', 'callback_events', 'disable_itemize',
     'disable_lstlisting', 'include_page_info', 'include_page_breaks', 'conversion_options',
 }
 
@@ -432,10 +433,9 @@ class MathpixClient:
             convert_to_html_zip: Optional[bool] = False,
             improve_mathpix: Optional[bool] = True,
             file_batch_id: Optional[str] = None,
-            webhook_url: Optional[str] = None,
-            mathpix_webhook_secret: Optional[str] = None,
-            webhook_payload: Optional[Dict[str, Any]] = None,
-            webhook_enabled_events: Optional[List[str]] = None,
+            callback_url: Optional[str] = None,
+            callback_headers: Optional[Dict[str, str]] = None,
+            callback_events: Optional[List[str]] = None,
             disable_itemize: Optional[bool] = None,
             disable_lstlisting: Optional[bool] = None,
             include_page_info: Optional[bool] = None,
@@ -479,10 +479,9 @@ class MathpixClient:
             convert_to_html_zip: Optional boolean to automatically convert your result to html.zip
             improve_mathpix: Optional boolean to enable Mathpix to retain user output. Default is true
             file_batch_id: Optional batch ID to associate this file with.
-            webhook_url: Optional URL to receive webhook notifications. (Not yet enabled)
-            mathpix_webhook_secret: Optional secret for webhook authentication. (Not yet enabled)
-            webhook_payload: Optional custom payload to include in webhooks. (Not yet enabled)
-            webhook_enabled_events: Optional list of events to trigger webhooks. (Not yet enabled)
+            callback_url: Optional URL to receive a webhook when processing completes. Overrides the account-default callback URL for this request
+            callback_headers: Optional dict of headers to include on the webhook delivery for this request
+            callback_events: Optional list of event names to subscribe to for this request
             disable_itemize: Optional boolean to disable itemize/enumerate list environments, rendering list items as flat lines
             disable_lstlisting: Optional boolean to disable the lstlisting environment for code blocks
             include_page_info: Optional boolean to include page info in the output
@@ -497,16 +496,9 @@ class MathpixClient:
             ValueError: If neither file_path nor url, or both file_path and url are provided.
             FileNotFoundError: If the specified file_path does not exist.
             MathpixClientError: If the API request fails.
-            NotImplementedError: If the API URL is set to the production API and webhook or file_batch_id parameters are provided.
+            NotImplementedError: If the API URL is set to the production API and the file_batch_id parameter is provided.
         """
         if self.auth.api_url == 'https://api.mathpix.com':
-            if any([webhook_url, mathpix_webhook_secret, webhook_payload, webhook_enabled_events]):
-                logger.warning("Webhook features not available in production API")
-                raise NotImplementedError(
-                    "Webhook features are not yet available in the production API. "
-                    "These features will be enabled in a future release."
-                )
-
             if file_batch_id:
                 logger.warning("File batch features not available in production API")
                 raise NotImplementedError(
@@ -581,14 +573,12 @@ class MathpixClient:
             options["conversion_options"] = conversion_options
         if file_batch_id:
             options["file_batch_id"] = file_batch_id
-        if webhook_url:
-            options["webhook_url"] = webhook_url
-        if mathpix_webhook_secret:
-            options["mathpix_webhook_secret"] = mathpix_webhook_secret
-        if webhook_payload:
-            options["webhook_payload"] = webhook_payload
-        if webhook_enabled_events:
-            options["webhook_enabled_events"] = webhook_enabled_events
+        if callback_url is not None:
+            options["callback_url"] = callback_url
+        if callback_headers is not None:
+            options["callback_headers"] = callback_headers
+        if callback_events is not None:
+            options["callback_events"] = callback_events
         if convert_to_docx:
             options["conversion_formats"]['docx'] = True
         if convert_to_md:
@@ -645,10 +635,9 @@ class MathpixClient:
                         convert_to_html_zip=convert_to_html_zip,
                         improve_mathpix=improve_mathpix,
                         file_batch_id=file_batch_id,
-                        webhook_url=webhook_url,
-                        mathpix_webhook_secret=mathpix_webhook_secret,
-                        webhook_payload=webhook_payload,
-                        webhook_enabled_events=webhook_enabled_events,
+                        callback_url=callback_url,
+                        callback_headers=callback_headers,
+                        callback_events=callback_events,
                         request_options=self.request_options,
                     )
                 except requests.exceptions.RequestException as e:
@@ -681,10 +670,9 @@ class MathpixClient:
                         convert_to_html_zip=convert_to_html_zip,
                         improve_mathpix=improve_mathpix,
                         file_batch_id=file_batch_id,
-                        webhook_url=webhook_url,
-                        mathpix_webhook_secret=mathpix_webhook_secret,
-                        webhook_payload=webhook_payload,
-                        webhook_enabled_events=webhook_enabled_events,
+                        callback_url=callback_url,
+                        callback_headers=callback_headers,
+                        callback_events=callback_events,
                         request_options=self.request_options,
                     )
             except Exception as e:
@@ -886,6 +874,9 @@ class MathpixClient:
             preserve_section_numbering: Optional[bool] = True,
             enable_tables_fallback: Optional[bool] = False,
             fullwidth_punctuation: Optional[bool] = None,
+            callback_url: Optional[str] = None,
+            callback_headers: Optional[Dict[str, str]] = None,
+            callback_events: Optional[List[str]] = None,
     ) -> File:
         """Submit a single document for async processing.
 
@@ -948,6 +939,13 @@ class MathpixClient:
             preserve_section_numbering: Keep existing section numbering (default True).
             enable_tables_fallback: Enable advanced table processing (default False).
             fullwidth_punctuation: Use fullwidth Unicode punctuation (default None).
+            callback_url: Optional URL to receive a webhook when processing
+                completes. Overrides the account-default callback URL set via
+                webhook_config_set for this request.
+            callback_headers: Optional dict of headers to include on the webhook
+                delivery for this request.
+            callback_events: Optional list of event names to subscribe to for
+                this request.
 
         Returns:
             File: A new File instance for polling status and downloading results.
@@ -1006,6 +1004,9 @@ class MathpixClient:
                 preserve_section_numbering=preserve_section_numbering,
                 enable_tables_fallback=enable_tables_fallback,
                 fullwidth_punctuation=fullwidth_punctuation,
+                callback_url=callback_url,
+                callback_headers=callback_headers,
+                callback_events=callback_events,
             )
         has_source_uri: bool = bool(source_uri)
         if not has_source_uri:
@@ -1033,6 +1034,12 @@ class MathpixClient:
             options["custom_id"] = custom_id
         if job_id:
             options["job_id"] = job_id
+        if callback_url is not None:
+            options["callback_url"] = callback_url
+        if callback_headers is not None:
+            options["callback_headers"] = callback_headers
+        if callback_events is not None:
+            options["callback_events"] = callback_events
         _apply_processing_options(
             options,
             alphabets_allowed=alphabets_allowed,
@@ -1106,6 +1113,9 @@ class MathpixClient:
             preserve_section_numbering: Optional[bool] = True,
             enable_tables_fallback: Optional[bool] = False,
             fullwidth_punctuation: Optional[bool] = None,
+            callback_url: Optional[str] = None,
+            callback_headers: Optional[Dict[str, str]] = None,
+            callback_events: Optional[List[str]] = None,
     ) -> File:
         """Upload a local file via multipart POST /files/v1 for file_new.
 
@@ -1128,6 +1138,12 @@ class MathpixClient:
             options["image_output_mode"] = image_output_mode
         if include_page_info is not None:
             options["include_page_info"] = include_page_info
+        if callback_url is not None:
+            options["callback_url"] = callback_url
+        if callback_headers is not None:
+            options["callback_headers"] = callback_headers
+        if callback_events is not None:
+            options["callback_events"] = callback_events
         _apply_processing_options(
             options,
             alphabets_allowed=alphabets_allowed,
@@ -1207,6 +1223,9 @@ class MathpixClient:
             preserve_section_numbering: Optional[bool] = True,
             enable_tables_fallback: Optional[bool] = False,
             fullwidth_punctuation: Optional[bool] = None,
+            callback_url: Optional[str] = None,
+            callback_headers: Optional[Dict[str, str]] = None,
+            callback_events: Optional[List[str]] = None,
     ) -> FileJob:
         """Submit a batch of documents for async processing in one call.
 
@@ -1261,6 +1280,12 @@ class MathpixClient:
             preserve_section_numbering: Keep existing section numbering (default True).
             enable_tables_fallback: Enable advanced table processing (default False).
             fullwidth_punctuation: Use fullwidth Unicode punctuation (default None).
+            callback_url: Optional URL to receive a webhook when the job's files
+                complete. Job-wide; overrides the account-default callback URL.
+            callback_headers: Optional dict of headers to include on the webhook
+                delivery. Job-wide.
+            callback_events: Optional list of event names to subscribe to.
+                Job-wide.
 
         Returns:
             FileJob: A new FileJob instance seeded with the response's job_id and
@@ -1310,6 +1335,12 @@ class MathpixClient:
             body["conversion_formats"] = conversion_formats
         if image_output_mode:
             body["image_output_mode"] = image_output_mode
+        if callback_url is not None:
+            body["callback_url"] = callback_url
+        if callback_headers is not None:
+            body["callback_headers"] = callback_headers
+        if callback_events is not None:
+            body["callback_events"] = callback_events
         _apply_processing_options(
             body,
             alphabets_allowed=alphabets_allowed,
@@ -1455,6 +1486,160 @@ class MathpixClient:
         job_status: Dict[str, Any] = job.status()
         job.file_count = job_status.get('file_count')
         return job
+
+    def file_job_finalize(self, job_id: str) -> Dict[str, Any]:
+        """Finalize a job so its terminal 'job.completed' webhook can fire.
+
+        Performs POST /files/v1/jobs/{job_id}/finalize. Finalizing marks the job
+        as closed to new submissions; once every submitted file reaches a
+        terminal state the 'job.completed' event is delivered to the configured
+        callback. The call is idempotent: a second finalize keeps the original
+        finalized_at.
+
+        Args:
+            job_id: The job's identifier.
+
+        Returns:
+            dict: Response containing 'job_id', 'finalized_at', and 'message'.
+
+        Raises:
+            FilesApiError: If the job does not exist ('not_found').
+            MathpixClientError: If the request fails without a Files API error body.
+        """
+        logger.debug(f"Finalizing job {job_id}")
+        endpoint: str = urljoin(self.auth.files_api_url, f'/files/v1/jobs/{job_id}/finalize')
+        try:
+            response: requests.Response = post(endpoint, headers=self.auth.headers, **self.request_options)
+            has_failed: bool = not response.ok
+            if has_failed:
+                raise error_from_response(response)
+            return response.json()
+        except requests.exceptions.RequestException as e:
+            raise MathpixClientError(f"Mathpix Files API finalize request failed: {e}")
+
+    def webhook_config_get(self) -> WebhookConfig:
+        """Get the account-default webhook configuration.
+
+        Performs GET /files/v1/webhook-config. The first call mints the signing
+        secret used to verify webhook delivery signatures (see
+        mpxpy.webhooks.verify_signature). Subsequent calls return the same
+        secret along with the account-default callback target.
+
+        Returns:
+            WebhookConfig: The current webhook configuration.
+
+        Raises:
+            FilesApiError: If the request fails with a Files API error body.
+            MathpixClientError: If the request fails without a Files API error body.
+        """
+        logger.debug("Getting webhook config")
+        endpoint: str = urljoin(self.auth.files_api_url, '/files/v1/webhook-config')
+        try:
+            response: requests.Response = get(endpoint, headers=self.auth.headers, **self.request_options)
+            has_failed: bool = not response.ok
+            if has_failed:
+                raise error_from_response(response)
+            return WebhookConfig(response.json())
+        except requests.exceptions.RequestException as e:
+            raise MathpixClientError(f"Mathpix webhook config request failed: {e}")
+
+    def webhook_config_set(
+            self,
+            default_callback_url: Optional[str] = None,
+            default_callback_headers: Optional[Dict[str, str]] = None,
+            default_callback_events: Optional[List[str]] = None,
+    ) -> WebhookConfig:
+        """Set the account-default webhook configuration.
+
+        Performs PUT /files/v1/webhook-config. Only the fields you provide are
+        sent, so an omitted field is left unchanged. Submissions that do not
+        pass their own callback_url fall back to this account default.
+
+        Args:
+            default_callback_url: Account-default callback URL for webhook deliveries.
+            default_callback_headers: Account-default headers (str->str) to include
+                on webhook deliveries.
+            default_callback_events: Non-empty list of event names to subscribe
+                to by default. Omit to use the server defaults; an empty list is
+                rejected.
+
+        Returns:
+            WebhookConfig: The updated webhook configuration.
+
+        Raises:
+            ValidationError: If default_callback_events is an empty list.
+            FilesApiError: If the request fails with a Files API error body.
+            MathpixClientError: If the request fails without a Files API error body.
+        """
+        body: Dict[str, Any] = {}
+        if default_callback_url is not None:
+            body["default_callback_url"] = default_callback_url
+        if default_callback_headers is not None:
+            body["default_callback_headers"] = default_callback_headers
+        if default_callback_events is not None:
+            has_events: bool = bool(default_callback_events)
+            if not has_events:
+                raise ValidationError("default_callback_events must be a non-empty list; omit it to use the defaults")
+            body["default_callback_events"] = default_callback_events
+        logger.debug("Setting webhook config")
+        endpoint: str = urljoin(self.auth.files_api_url, '/files/v1/webhook-config')
+        try:
+            response: requests.Response = put(endpoint, json=body, headers=self.auth.headers, **self.request_options)
+            has_failed: bool = not response.ok
+            if has_failed:
+                raise error_from_response(response)
+            return WebhookConfig(response.json())
+        except requests.exceptions.RequestException as e:
+            raise MathpixClientError(f"Mathpix webhook config request failed: {e}")
+
+    def webhook_config_test(self) -> Dict[str, Any]:
+        """Send a test webhook to the configured default callback URL.
+
+        Performs POST /files/v1/webhook-config/test. The API returns HTTP 200
+        for both a delivered and a failed probe; this method returns the probe
+        body as-is and does NOT raise on a failed delivery (mirroring
+        data_source_test). It raises only if no default_callback_url is
+        configured or the request itself fails.
+
+        Returns:
+            dict: The probe body, containing 'status' ('delivered' or 'failed'),
+                'response_code' (int or None), and 'detail'.
+
+        Raises:
+            FilesApiError: If the request itself fails (e.g. no default callback
+                URL configured).
+            MathpixClientError: If the request fails without a Files API error body.
+        """
+        logger.debug("Testing webhook config")
+        endpoint: str = urljoin(self.auth.files_api_url, '/files/v1/webhook-config/test')
+        try:
+            response: requests.Response = post(endpoint, headers=self.auth.headers, **self.request_options)
+            has_failed: bool = not response.ok
+            if has_failed:
+                raise error_from_response(response)
+            return response.json()
+        except requests.exceptions.RequestException as e:
+            raise MathpixClientError(f"Mathpix webhook config test request failed: {e}")
+
+    @staticmethod
+    def verify_signature(
+            signature_header: str,
+            body: Union[bytes, str],
+            secret: str,
+            tolerance_seconds: int = 300,
+    ) -> bool:
+        """Verify a Mathpix webhook signature.
+
+        Convenience delegate to mpxpy.webhooks.verify_signature. Recomputes the
+        HMAC-SHA256 over the raw request body and compares it, in constant time,
+        to the header's v1 value, rejecting deliveries outside the replay
+        window. See mpxpy.webhooks.verify_signature for the full scheme.
+
+        Returns:
+            bool: True if the signature is valid and within the replay window,
+                False for any invalid or malformed input. Never raises.
+        """
+        return _verify_signature(signature_header, body, secret, tolerance_seconds)
 
     def onboarding_identities(self) -> Dict[str, Any]:
         """Get the Mathpix identities you grant cloud storage access to.

--- a/mpxpy/pdf.py
+++ b/mpxpy/pdf.py
@@ -32,10 +32,9 @@ class Pdf:
         convert_to_html_zip: Optional boolean to automatically convert your result to html.zip
         improve_mathpix: Optional boolean to enable Mathpix to retain user output. Default is true
         file_batch_id: Optional batch ID to associate this file with. (Not yet enabled)
-        webhook_url: Optional URL to receive webhook notifications. (Not yet enabled)
-        mathpix_webhook_secret: Optional secret for webhook authentication. (Not yet enabled)
-        webhook_payload: Optional custom payload to include in webhooks. (Not yet enabled)
-        webhook_enabled_events: Optional list of events to trigger webhooks. (Not yet enabled)
+        callback_url: Optional URL to receive a webhook when processing completes.
+        callback_headers: Optional dict of headers to include on the webhook delivery.
+        callback_events: Optional list of event names to subscribe to.
     """
     def __init__(
             self,
@@ -55,10 +54,9 @@ class Pdf:
             convert_to_html_zip: Optional[bool] = False,
             improve_mathpix: Optional[bool] = False,
             file_batch_id: Optional[str] = None,
-            webhook_url: Optional[str] = None,
-            mathpix_webhook_secret: Optional[str] = None,
-            webhook_payload: Optional[Dict[str, Any]] = None,
-            webhook_enabled_events: Optional[List[str]] = None,
+            callback_url: Optional[str] = None,
+            callback_headers: Optional[Dict[str, str]] = None,
+            callback_events: Optional[List[str]] = None,
             request_options: Optional[Dict[str, Any]] = None,
     ):
         """Initialize a PDF instance.
@@ -80,10 +78,9 @@ class Pdf:
             convert_to_html_zip: Optional boolean to automatically convert your result to html.zip
             improve_mathpix: Optional boolean to enable Mathpix to retain user output. Default is true
             file_batch_id: Optional batch ID to associate this file with. (Not yet enabled)
-            webhook_url: Optional URL to receive webhook notifications. (Not yet enabled)
-            mathpix_webhook_secret: Optional secret for webhook authentication. (Not yet enabled)
-            webhook_payload: Optional custom payload to include in webhooks. (Not yet enabled)
-            webhook_enabled_events: Optional list of events to trigger webhooks. (Not yet enabled)
+            callback_url: Optional URL to receive a webhook when processing completes.
+            callback_headers: Optional dict of headers to include on the webhook delivery.
+            callback_events: Optional list of event names to subscribe to.
 
         Raises:
             ValueError: If auth is not provided or pdf_id is empty.
@@ -110,10 +107,9 @@ class Pdf:
         self.convert_to_html_zip = convert_to_html_zip
         self.improve_mathpix=improve_mathpix
         self.file_batch_id = file_batch_id
-        self.webhook_url = webhook_url
-        self.mathpix_webhook_secret = mathpix_webhook_secret
-        self.webhook_payload = webhook_payload
-        self.webhook_enabled_events = webhook_enabled_events
+        self.callback_url = callback_url
+        self.callback_headers = callback_headers
+        self.callback_events = callback_events
         self.request_options = request_options or {}
 
     def wait_until_complete(self, timeout: int=60, ignore_conversions: bool=False):

--- a/mpxpy/pdf.py
+++ b/mpxpy/pdf.py
@@ -32,9 +32,9 @@ class Pdf:
         convert_to_html_zip: Optional boolean to automatically convert your result to html.zip
         improve_mathpix: Optional boolean to enable Mathpix to retain user output. Default is true
         file_batch_id: Optional batch ID to associate this file with. (Not yet enabled)
-        callback_url: Optional URL to receive a webhook when processing completes.
-        callback_headers: Optional dict of headers to include on the webhook delivery.
-        callback_events: Optional list of event names to subscribe to.
+        callback_url: Optional HTTPS URL to receive this request's webhook deliveries.
+        callback_headers: Optional dict of headers sent on this request's deliveries.
+        callback_events: Optional list of event names for this request; one document defaults to ['file.completed', 'file.error'].
     """
     def __init__(
             self,
@@ -78,9 +78,9 @@ class Pdf:
             convert_to_html_zip: Optional boolean to automatically convert your result to html.zip
             improve_mathpix: Optional boolean to enable Mathpix to retain user output. Default is true
             file_batch_id: Optional batch ID to associate this file with. (Not yet enabled)
-            callback_url: Optional URL to receive a webhook when processing completes.
-            callback_headers: Optional dict of headers to include on the webhook delivery.
-            callback_events: Optional list of event names to subscribe to.
+            callback_url: Optional HTTPS URL to receive this request's webhook deliveries.
+            callback_headers: Optional dict of headers sent on this request's deliveries.
+            callback_events: Optional list of event names for this request; one document defaults to ['file.completed', 'file.error'].
 
         Raises:
             ValueError: If auth is not provided or pdf_id is empty.

--- a/mpxpy/webhooks.py
+++ b/mpxpy/webhooks.py
@@ -75,82 +75,24 @@ def verify_signature(
 
 
 class WebhookConfig:
-    """The account-default webhook configuration for the Files API.
+    """The webhook configuration for the Files API.
 
-    Returned by ``MathpixClient.webhook_config_get`` and
-    ``MathpixClient.webhook_config_set``. Wraps the webhook-config response with
-    read-only properties: the signing secret used to verify delivery signatures
-    and the account-default callback target applied to submissions that do not
-    override it per-request.
+    Returned by ``MathpixClient.webhook_config_get``. Wraps the webhook-config
+    response, exposing the signing secret used to verify webhook delivery
+    signatures (see ``mpxpy.webhooks.verify_signature``).
 
     Attributes:
         signing_secret: The secret used to sign and verify webhook deliveries.
-        callback_url: The account-default callback URL, or None.
-        callback_headers: Account-default callback headers, or None.
-        callback_events: Account-default subscribed event names, or None.
     """
     def __init__(self, response: Dict[str, Any]) -> None:
         """Initialize a WebhookConfig from a webhook-config response dict.
 
         Args:
-            response: The JSON body from GET/PUT /files/v1/webhook-config. Its
-                keys are the wire names default_callback_url/headers/events;
-                they are exposed here under the bare callback_* names.
+            response: The JSON body from GET /files/v1/webhook-config.
         """
         self._signing_secret: Optional[str] = response.get('signing_secret')
-        self._callback_url: Optional[str] = response.get('default_callback_url')
-        self._callback_headers: Optional[Dict[str, str]] = response.get('default_callback_headers')
-        self._callback_events: Optional[List[str]] = response.get('default_callback_events')
 
     @property
     def signing_secret(self) -> Optional[str]:
         """The secret used to sign and verify webhook deliveries."""
         return self._signing_secret
-
-    @property
-    def callback_url(self) -> Optional[str]:
-        """The account-default callback URL, or None."""
-        return self._callback_url
-
-    @property
-    def callback_headers(self) -> Optional[Dict[str, str]]:
-        """The account-default callback headers, or None."""
-        return self._callback_headers
-
-    @property
-    def callback_events(self) -> Optional[List[str]]:
-        """The account-default subscribed event names, or None."""
-        return self._callback_events
-
-    @classmethod
-    def from_callback_values(
-            cls,
-            callback_url: Optional[str] = None,
-            callback_headers: Optional[Dict[str, str]] = None,
-            callback_events: Optional[List[str]] = None,
-    ) -> "WebhookConfig":
-        """Build a WebhookConfig from bare callback values (no signing secret).
-
-        Used to assemble the write-direction payload after a read-modify-write
-        merge, so the wire key names stay owned by this class rather than the
-        client method that writes them.
-        """
-        config: "WebhookConfig" = cls({})
-        config._callback_url = callback_url
-        config._callback_headers = callback_headers
-        config._callback_events = callback_events
-        return config
-
-    def to_request_body(self) -> Dict[str, Any]:
-        """Return the PUT /files/v1/webhook-config write payload.
-
-        Emits all three ``default_callback_*`` wire keys (the server replaces the
-        whole configuration on write, so every field is sent) and deliberately
-        excludes the server-managed ``signing_secret``. This is the single place
-        the write-direction wire key names live.
-        """
-        return {
-            'default_callback_url': self._callback_url,
-            'default_callback_headers': self._callback_headers,
-            'default_callback_events': self._callback_events,
-        }

--- a/mpxpy/webhooks.py
+++ b/mpxpy/webhooks.py
@@ -78,20 +78,22 @@ class WebhookConfig:
 
     Attributes:
         signing_secret: The secret used to sign and verify webhook deliveries.
-        default_callback_url: The account-default callback URL, or None.
-        default_callback_headers: Account-default callback headers, or None.
-        default_callback_events: Account-default subscribed event names, or None.
+        callback_url: The account-default callback URL, or None.
+        callback_headers: Account-default callback headers, or None.
+        callback_events: Account-default subscribed event names, or None.
     """
     def __init__(self, response: Dict[str, Any]) -> None:
         """Initialize a WebhookConfig from a webhook-config response dict.
 
         Args:
-            response: The JSON body from GET/PUT /files/v1/webhook-config.
+            response: The JSON body from GET/PUT /files/v1/webhook-config. Its
+                keys are the wire names default_callback_url/headers/events;
+                they are exposed here under the bare callback_* names.
         """
         self._signing_secret: Optional[str] = response.get('signing_secret')
-        self._default_callback_url: Optional[str] = response.get('default_callback_url')
-        self._default_callback_headers: Optional[Dict[str, str]] = response.get('default_callback_headers')
-        self._default_callback_events: Optional[List[str]] = response.get('default_callback_events')
+        self._callback_url: Optional[str] = response.get('default_callback_url')
+        self._callback_headers: Optional[Dict[str, str]] = response.get('default_callback_headers')
+        self._callback_events: Optional[List[str]] = response.get('default_callback_events')
 
     @property
     def signing_secret(self) -> Optional[str]:
@@ -99,26 +101,26 @@ class WebhookConfig:
         return self._signing_secret
 
     @property
-    def default_callback_url(self) -> Optional[str]:
+    def callback_url(self) -> Optional[str]:
         """The account-default callback URL, or None."""
-        return self._default_callback_url
+        return self._callback_url
 
     @property
-    def default_callback_headers(self) -> Optional[Dict[str, str]]:
+    def callback_headers(self) -> Optional[Dict[str, str]]:
         """The account-default callback headers, or None."""
-        return self._default_callback_headers
+        return self._callback_headers
 
     @property
-    def default_callback_events(self) -> Optional[List[str]]:
+    def callback_events(self) -> Optional[List[str]]:
         """The account-default subscribed event names, or None."""
-        return self._default_callback_events
+        return self._callback_events
 
     def to_dict(self) -> Dict[str, Any]:
         """Return the configuration as a dict, omitting unset fields."""
         fields: Dict[str, Any] = {
             'signing_secret': self._signing_secret,
-            'default_callback_url': self._default_callback_url,
-            'default_callback_headers': self._default_callback_headers,
-            'default_callback_events': self._default_callback_events,
+            'callback_url': self._callback_url,
+            'callback_headers': self._callback_headers,
+            'callback_events': self._callback_events,
         }
         return {key: value for key, value in fields.items() if value is not None}

--- a/mpxpy/webhooks.py
+++ b/mpxpy/webhooks.py
@@ -20,9 +20,11 @@ def verify_signature(
     with ``MathpixClient.webhook_config_get().signing_secret``.
 
     This function recomputes that HMAC over the raw request body and
-    constant-time compares it to the header's ``v1`` value, so it must be
+    constant-time compares it to the header's ``v1`` value(s), so it must be
     called with the exact bytes Mathpix sent, before any JSON parsing or
-    re-serialization changes them.
+    re-serialization changes them. A single header may carry more than one
+    ``v1`` entry during a secret rotation (the new and previous secret are both
+    signed for ~24h); the delivery is accepted if any ``v1`` matches.
 
     A replay window guards against a captured-and-replayed delivery: the
     signature is rejected when the header timestamp is more than
@@ -31,7 +33,8 @@ def verify_signature(
     Args:
         signature_header: The raw ``Mathpix-Signature`` header value.
         body: The exact raw request body, as bytes or a str (encoded UTF-8).
-        secret: The webhook signing secret.
+        secret: The webhook signing secret. An empty or otherwise falsy secret
+            fails closed (returns False) rather than keying the HMAC with it.
         tolerance_seconds: Maximum allowed age of the signature timestamp, in
             seconds (default 300). Deliveries outside this window are rejected.
 
@@ -40,20 +43,24 @@ def verify_signature(
             False for any invalid, malformed, or missing input. Never raises.
     """
     try:
-        has_inputs: bool = bool(signature_header) and secret is not None and body is not None
+        has_inputs: bool = bool(signature_header) and bool(secret) and body is not None
         if not has_inputs:
             return False
-        parsed: Dict[str, str] = {}
+        timestamp: Optional[str] = None
+        provided_signatures: List[str] = []
         for part in signature_header.split(','):
             has_separator: bool = '=' in part
             if not has_separator:
                 continue
             key, value = part.split('=', 1)
-            parsed[key.strip()] = value.strip()
-        timestamp: Optional[str] = parsed.get('t')
-        provided_signature: Optional[str] = parsed.get('v1')
-        has_required_fields: bool = bool(timestamp) and bool(provided_signature)
-        if not has_required_fields:
+            key = key.strip()
+            value = value.strip()
+            if key == 't':
+                timestamp = value
+            elif key == 'v1':
+                provided_signatures.append(value)
+        has_v1: bool = len(provided_signatures) > 0
+        if timestamp is None or not has_v1:
             return False
         timestamp_seconds: int = int(timestamp)
         is_within_window: bool = abs(time.time() - timestamp_seconds) <= tolerance_seconds
@@ -62,7 +69,7 @@ def verify_signature(
         body_bytes: bytes = body.encode('utf-8') if isinstance(body, str) else body
         message: bytes = f"{timestamp}.".encode('utf-8') + body_bytes
         expected_signature: str = hmac.new(secret.encode('utf-8'), message, hashlib.sha256).hexdigest()
-        return hmac.compare_digest(expected_signature, provided_signature)
+        return any(hmac.compare_digest(expected_signature, provided) for provided in provided_signatures)
     except Exception:
         return False
 
@@ -115,12 +122,35 @@ class WebhookConfig:
         """The account-default subscribed event names, or None."""
         return self._callback_events
 
-    def to_dict(self) -> Dict[str, Any]:
-        """Return the configuration as a dict, omitting unset fields."""
-        fields: Dict[str, Any] = {
-            'signing_secret': self._signing_secret,
-            'callback_url': self._callback_url,
-            'callback_headers': self._callback_headers,
-            'callback_events': self._callback_events,
+    @classmethod
+    def from_callback_values(
+            cls,
+            callback_url: Optional[str] = None,
+            callback_headers: Optional[Dict[str, str]] = None,
+            callback_events: Optional[List[str]] = None,
+    ) -> "WebhookConfig":
+        """Build a WebhookConfig from bare callback values (no signing secret).
+
+        Used to assemble the write-direction payload after a read-modify-write
+        merge, so the wire key names stay owned by this class rather than the
+        client method that writes them.
+        """
+        config: "WebhookConfig" = cls({})
+        config._callback_url = callback_url
+        config._callback_headers = callback_headers
+        config._callback_events = callback_events
+        return config
+
+    def to_request_body(self) -> Dict[str, Any]:
+        """Return the PUT /files/v1/webhook-config write payload.
+
+        Emits all three ``default_callback_*`` wire keys (the server replaces the
+        whole configuration on write, so every field is sent) and deliberately
+        excludes the server-managed ``signing_secret``. This is the single place
+        the write-direction wire key names live.
+        """
+        return {
+            'default_callback_url': self._callback_url,
+            'default_callback_headers': self._callback_headers,
+            'default_callback_events': self._callback_events,
         }
-        return {key: value for key, value in fields.items() if value is not None}

--- a/mpxpy/webhooks.py
+++ b/mpxpy/webhooks.py
@@ -34,8 +34,9 @@ def verify_signature(
     Args:
         signature_header: The raw ``Mathpix-Signature`` header value.
         body: The exact raw request body, as bytes or a str (encoded UTF-8).
-        secret: The webhook signing secret. An empty or otherwise falsy secret
-            fails closed (returns False) rather than keying the HMAC with it.
+        secret: Your webhook signing secret. An empty or otherwise falsy
+            secret fails closed (returns False) rather than keying the HMAC
+            with it.
         tolerance_seconds: Maximum allowed age of the signature timestamp, in
             seconds (default 300). Deliveries outside this window are rejected.
 
@@ -80,7 +81,9 @@ class WebhookConfig:
 
     Returned by ``MathpixClient.webhook_config_get``. Wraps the webhook-config
     response, exposing the signing secret used to verify webhook delivery
-    signatures (see ``mpxpy.webhooks.verify_signature``).
+    signatures (see ``mpxpy.webhooks.verify_signature``). The signing secret is
+    the whole stored configuration: where a delivery goes, what headers it
+    carries, and which events fire are per-submission callback arguments.
 
     Attributes:
         signing_secret: The secret used to sign and verify webhook deliveries.

--- a/mpxpy/webhooks.py
+++ b/mpxpy/webhooks.py
@@ -1,0 +1,124 @@
+import hmac
+import hashlib
+import time
+from typing import Optional, Dict, Any, List, Union
+
+
+def verify_signature(
+        signature_header: str,
+        body: Union[bytes, str],
+        secret: str,
+        tolerance_seconds: int = 300,
+) -> bool:
+    """Verify a Mathpix webhook signature.
+
+    Mathpix signs each webhook delivery with the header
+    ``Mathpix-Signature: t=<unix_seconds>,v1=<hex>`` where ``<hex>`` is the
+    lowercase hex HMAC-SHA256 of the string ``"{t}.{raw_body}"`` (the
+    unix-seconds timestamp, a literal dot, then the exact raw request body),
+    keyed by the UTF-8 bytes of your webhook signing secret. Fetch the secret
+    with ``MathpixClient.webhook_config_get().signing_secret``.
+
+    This function recomputes that HMAC over the raw request body and
+    constant-time compares it to the header's ``v1`` value, so it must be
+    called with the exact bytes Mathpix sent, before any JSON parsing or
+    re-serialization changes them.
+
+    A replay window guards against a captured-and-replayed delivery: the
+    signature is rejected when the header timestamp is more than
+    ``tolerance_seconds`` away from the current time in either direction.
+
+    Args:
+        signature_header: The raw ``Mathpix-Signature`` header value.
+        body: The exact raw request body, as bytes or a str (encoded UTF-8).
+        secret: The webhook signing secret.
+        tolerance_seconds: Maximum allowed age of the signature timestamp, in
+            seconds (default 300). Deliveries outside this window are rejected.
+
+    Returns:
+        bool: True if the signature is valid and within the replay window,
+            False for any invalid, malformed, or missing input. Never raises.
+    """
+    try:
+        has_inputs: bool = bool(signature_header) and secret is not None and body is not None
+        if not has_inputs:
+            return False
+        parsed: Dict[str, str] = {}
+        for part in signature_header.split(','):
+            has_separator: bool = '=' in part
+            if not has_separator:
+                continue
+            key, value = part.split('=', 1)
+            parsed[key.strip()] = value.strip()
+        timestamp: Optional[str] = parsed.get('t')
+        provided_signature: Optional[str] = parsed.get('v1')
+        has_required_fields: bool = bool(timestamp) and bool(provided_signature)
+        if not has_required_fields:
+            return False
+        timestamp_seconds: int = int(timestamp)
+        is_within_window: bool = abs(time.time() - timestamp_seconds) <= tolerance_seconds
+        if not is_within_window:
+            return False
+        body_bytes: bytes = body.encode('utf-8') if isinstance(body, str) else body
+        message: bytes = f"{timestamp}.".encode('utf-8') + body_bytes
+        expected_signature: str = hmac.new(secret.encode('utf-8'), message, hashlib.sha256).hexdigest()
+        return hmac.compare_digest(expected_signature, provided_signature)
+    except Exception:
+        return False
+
+
+class WebhookConfig:
+    """The account-default webhook configuration for the Files API.
+
+    Returned by ``MathpixClient.webhook_config_get`` and
+    ``MathpixClient.webhook_config_set``. Wraps the webhook-config response with
+    read-only properties: the signing secret used to verify delivery signatures
+    and the account-default callback target applied to submissions that do not
+    override it per-request.
+
+    Attributes:
+        signing_secret: The secret used to sign and verify webhook deliveries.
+        default_callback_url: The account-default callback URL, or None.
+        default_callback_headers: Account-default callback headers, or None.
+        default_callback_events: Account-default subscribed event names, or None.
+    """
+    def __init__(self, response: Dict[str, Any]) -> None:
+        """Initialize a WebhookConfig from a webhook-config response dict.
+
+        Args:
+            response: The JSON body from GET/PUT /files/v1/webhook-config.
+        """
+        self._signing_secret: Optional[str] = response.get('signing_secret')
+        self._default_callback_url: Optional[str] = response.get('default_callback_url')
+        self._default_callback_headers: Optional[Dict[str, str]] = response.get('default_callback_headers')
+        self._default_callback_events: Optional[List[str]] = response.get('default_callback_events')
+
+    @property
+    def signing_secret(self) -> Optional[str]:
+        """The secret used to sign and verify webhook deliveries."""
+        return self._signing_secret
+
+    @property
+    def default_callback_url(self) -> Optional[str]:
+        """The account-default callback URL, or None."""
+        return self._default_callback_url
+
+    @property
+    def default_callback_headers(self) -> Optional[Dict[str, str]]:
+        """The account-default callback headers, or None."""
+        return self._default_callback_headers
+
+    @property
+    def default_callback_events(self) -> Optional[List[str]]:
+        """The account-default subscribed event names, or None."""
+        return self._default_callback_events
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return the configuration as a dict, omitting unset fields."""
+        fields: Dict[str, Any] = {
+            'signing_secret': self._signing_secret,
+            'default_callback_url': self._default_callback_url,
+            'default_callback_headers': self._default_callback_headers,
+            'default_callback_events': self._default_callback_events,
+        }
+        return {key: value for key, value in fields.items() if value is not None}

--- a/mpxpy/webhooks.py
+++ b/mpxpy/webhooks.py
@@ -22,9 +22,10 @@ def verify_signature(
     This function recomputes that HMAC over the raw request body and
     constant-time compares it to the header's ``v1`` value(s), so it must be
     called with the exact bytes Mathpix sent, before any JSON parsing or
-    re-serialization changes them. A single header may carry more than one
-    ``v1`` entry during a secret rotation (the new and previous secret are both
-    signed for ~24h); the delivery is accepted if any ``v1`` matches.
+    re-serialization changes them. A delivery header carries a single ``v1``
+    value today; this function also accepts a header bearing more than one
+    ``v1`` and passes if any one matches, so it keeps working if signature
+    rotation is added later.
 
     A replay window guards against a captured-and-replayed delivery: the
     signature is rejected when the header timestamp is more than

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mpxpy"
-version = "0.0.21"
+version = "0.0.22"
 description = "Official Mathpix client for Python"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/tests/run_file_batch_conversion.py
+++ b/tests/run_file_batch_conversion.py
@@ -19,12 +19,8 @@ def process_pdf_folder(client):
         client.pdf_new(
             file_path=pdf_file_path,
             file_batch_id=file_batch.file_batch_id,
-            webhook_url="http://gateway:8080/webhook/convert-api",
-            mathpix_webhook_secret="test-secret",
-            webhook_payload={
-                "data": "test data"
-            },
-            webhook_enabled_events=["pdf_processing_complete"],
+            callback_url="http://gateway:8080/webhook/convert-api",
+            callback_events=["pdf_processing_complete"],
             conversion_formats={
                 "docx": True
             }

--- a/tests/run_file_batch_conversion.py
+++ b/tests/run_file_batch_conversion.py
@@ -20,7 +20,7 @@ def process_pdf_folder(client):
             file_path=pdf_file_path,
             file_batch_id=file_batch.file_batch_id,
             callback_url="http://gateway:8080/webhook/convert-api",
-            callback_events=["pdf_processing_complete"],
+            callback_events=["file.completed"],
             conversion_formats={
                 "docx": True
             }

--- a/tests/test_files_api_unit.py
+++ b/tests/test_files_api_unit.py
@@ -331,6 +331,83 @@ def test_file_job_new_idempotency_key_header(client: MathpixClient) -> None:
     assert kwargs['headers']['Idempotency-Key'] == 'batch-key-1'
 
 
+# callback serialization
+# The reserved-key guard on file_new/file_job_new only matters if the explicit
+# callback args actually reach the request body; these lock in that they do.
+
+CALLBACK_URL = 'https://hook.example.com/cb'
+CALLBACK_HEADERS = {'Authorization': 'Bearer t'}
+CALLBACK_EVENTS = ['file.completed', 'job.completed']
+
+
+def test_file_new_uri_serializes_callback_params(client: MathpixClient) -> None:
+    with patch('mpxpy.mathpix_client.post') as mock_post:
+        mock_post.return_value = FakeResponse(json_body={'file_id': 'abc-123'})
+        client.file_new(
+            source_uri='s3://bucket/doc.pdf',
+            callback_url=CALLBACK_URL,
+            callback_headers=CALLBACK_HEADERS,
+            callback_events=CALLBACK_EVENTS,
+        )
+    _, kwargs = mock_post.call_args
+    body = kwargs['json']
+    assert body['callback_url'] == CALLBACK_URL
+    assert body['callback_headers'] == CALLBACK_HEADERS
+    assert body['callback_events'] == CALLBACK_EVENTS
+
+
+def test_file_new_multipart_serializes_callback_params(client: MathpixClient, tmp_path) -> None:
+    doc = tmp_path / 'doc.pdf'
+    doc.write_bytes(b'%PDF-1.4 test')
+    with patch('mpxpy.mathpix_client.post') as mock_post:
+        mock_post.return_value = FakeResponse(json_body={'file_id': 'f-local'})
+        client.file_new(
+            file_path=str(doc),
+            callback_url=CALLBACK_URL,
+            callback_headers=CALLBACK_HEADERS,
+            callback_events=CALLBACK_EVENTS,
+        )
+    _, kwargs = mock_post.call_args
+    options = json.loads(kwargs['data']['options_json'])
+    assert options['callback_url'] == CALLBACK_URL
+    assert options['callback_headers'] == CALLBACK_HEADERS
+    assert options['callback_events'] == CALLBACK_EVENTS
+
+
+def test_pdf_new_serializes_callback_params(client: MathpixClient, tmp_path) -> None:
+    doc = tmp_path / 'doc.pdf'
+    doc.write_bytes(b'%PDF-1.4 test')
+    with patch('mpxpy.mathpix_client.post') as mock_post:
+        mock_post.return_value = FakeResponse(json_body={'pdf_id': 'p-1'})
+        client.pdf_new(
+            file_path=str(doc),
+            callback_url=CALLBACK_URL,
+            callback_headers=CALLBACK_HEADERS,
+            callback_events=CALLBACK_EVENTS,
+        )
+    _, kwargs = mock_post.call_args
+    options = json.loads(kwargs['data']['options_json'])
+    assert options['callback_url'] == CALLBACK_URL
+    assert options['callback_headers'] == CALLBACK_HEADERS
+    assert options['callback_events'] == CALLBACK_EVENTS
+
+
+def test_file_job_new_serializes_callback_params(client: MathpixClient) -> None:
+    with patch('mpxpy.mathpix_client.post') as mock_post:
+        mock_post.return_value = FakeResponse(json_body={'job_id': 'job-1', 'file_count': 1})
+        client.file_job_new(
+            files=[{'source_uri': 's3://bucket/a.pdf'}],
+            callback_url=CALLBACK_URL,
+            callback_headers=CALLBACK_HEADERS,
+            callback_events=CALLBACK_EVENTS,
+        )
+    _, kwargs = mock_post.call_args
+    body = kwargs['json']
+    assert body['callback_url'] == CALLBACK_URL
+    assert body['callback_headers'] == CALLBACK_HEADERS
+    assert body['callback_events'] == CALLBACK_EVENTS
+
+
 # file_job_list
 
 def test_file_job_list_params(client: MathpixClient) -> None:

--- a/tests/test_files_api_unit.py
+++ b/tests/test_files_api_unit.py
@@ -408,6 +408,21 @@ def test_file_job_new_serializes_callback_params(client: MathpixClient) -> None:
     assert body['callback_events'] == CALLBACK_EVENTS
 
 
+def test_callback_events_empty_list_is_sent(client: MathpixClient) -> None:
+    # An empty list is the documented off switch for one submission, so it must
+    # reach the wire rather than being dropped as a falsy value: absent means
+    # "the default for this submission's shape", [] means "no deliveries".
+    with patch('mpxpy.mathpix_client.post') as mock_post:
+        mock_post.return_value = FakeResponse(json_body={'file_id': 'abc-123'})
+        client.file_new(
+            source_uri='s3://bucket/doc.pdf',
+            callback_url=CALLBACK_URL,
+            callback_events=[],
+        )
+    _, kwargs = mock_post.call_args
+    assert kwargs['json']['callback_events'] == []
+
+
 # file_job_list
 
 def test_file_job_list_params(client: MathpixClient) -> None:

--- a/tests/test_request_options_unit.py
+++ b/tests/test_request_options_unit.py
@@ -77,8 +77,8 @@ def test_pdf_new_sends_documented_and_extra_options(client: MathpixClient, tmp_p
 
 def test_pdf_new_rejects_modeled_extra_options(client: MathpixClient) -> None:
     for key in (
-            'url', 'metadata', 'conversion_formats', 'file_batch_id', 'webhook_url',
-            'mathpix_webhook_secret', 'webhook_payload', 'webhook_enabled_events',
+            'url', 'metadata', 'conversion_formats', 'file_batch_id', 'callback_url',
+            'callback_headers', 'callback_events',
             'conversion_options',
     ):
         with pytest.raises(ValidationError):

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -103,68 +103,16 @@ def test_verify_signature_accepts_any_of_multiple_v1() -> None:
     assert verify_signature(f"t={t},v1={wrong},v1={wrong}", body, SECRET) is False
 
 
-# webhook_config_get / set / test
+# webhook_config_get
 
-def test_webhook_config_get_returns_config(client: MathpixClient) -> None:
-    # The response carries the default_callback_* wire keys; WebhookConfig
-    # exposes them under the bare callback_* names.
-    config_body = {
-        "signing_secret": "whsec_abc",
-        "default_callback_url": "https://example.com/hook",
-        "default_callback_headers": {"X-Token": "t"},
-        "default_callback_events": ["job.completed"],
-    }
+def test_webhook_config_get_returns_signing_secret(client: MathpixClient) -> None:
     with patch("mpxpy.mathpix_client.get") as mock_get:
-        mock_get.return_value = FakeResponse(json_body=config_body)
+        mock_get.return_value = FakeResponse(json_body={"signing_secret": "whsec_abc"})
         config = client.webhook_config_get()
     assert isinstance(config, WebhookConfig)
     assert config.signing_secret == "whsec_abc"
-    assert config.callback_url == "https://example.com/hook"
-    assert config.callback_headers == {"X-Token": "t"}
-    assert config.callback_events == ["job.completed"]
     args, _ = mock_get.call_args
     assert args[0].endswith("/files/v1/webhook-config")
-
-
-def test_webhook_config_set_preserves_unspecified_fields(client: MathpixClient) -> None:
-    # Read-modify-write: setting only callback_url must preserve the existing headers
-    # and events (the API's PUT is full-replacement, so the SDK reads then merges).
-    # The bare callback_* params map onto the default_callback_* wire keys.
-    current = {
-        "signing_secret": "whsec_abc",
-        "default_callback_url": "https://old.example.com/hook",
-        "default_callback_headers": {"Authorization": "Bearer keep"},
-        "default_callback_events": ["file.completed"],
-    }
-    with patch("mpxpy.mathpix_client.get") as mock_get, \
-            patch("mpxpy.mathpix_client.put") as mock_put:
-        mock_get.return_value = FakeResponse(json_body=current)
-        mock_put.return_value = FakeResponse(json_body={**current, "default_callback_url": "https://new.example.com/hook"})
-        config = client.webhook_config_set(callback_url="https://new.example.com/hook")
-    assert isinstance(config, WebhookConfig)
-    assert mock_get.called  # read-modify-write read the current config first
-    args, kwargs = mock_put.call_args
-    assert args[0].endswith("/files/v1/webhook-config")
-    assert kwargs["json"] == {
-        "default_callback_url": "https://new.example.com/hook",
-        "default_callback_headers": {"Authorization": "Bearer keep"},
-        "default_callback_events": ["file.completed"],
-    }
-
-
-def test_webhook_config_set_rejects_empty_events(client: MathpixClient) -> None:
-    with pytest.raises(ValidationError):
-        client.webhook_config_set(callback_events=[])
-
-
-def test_webhook_config_test_returns_probe_without_raising(client: MathpixClient) -> None:
-    probe = {"status": "failed", "response_code": 500, "detail": "endpoint returned 500"}
-    with patch("mpxpy.mathpix_client.post") as mock_post:
-        mock_post.return_value = FakeResponse(json_body=probe)
-        result = client.webhook_config_test()
-    assert result == probe
-    args, _ = mock_post.call_args
-    assert args[0].endswith("/files/v1/webhook-config/test")
 
 
 # FileJob.finalize

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -12,7 +12,7 @@ import pytest
 from mpxpy.mathpix_client import MathpixClient
 from mpxpy.file_job import FileJob
 from mpxpy.webhooks import verify_signature, WebhookConfig
-from mpxpy.errors import ValidationError, FilesApiError
+from mpxpy.errors import FilesApiError
 
 
 SECRET = "whsec_test_secret"

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -1,0 +1,148 @@
+"""Unit tests for webhook signature verification and the webhook config surface.
+
+The signature tests use only the standard library; the client tests mock the
+request layer, so no network access is required.
+"""
+import hashlib
+import hmac
+import time
+from typing import Any, Dict, Optional
+from unittest.mock import patch
+import pytest
+from mpxpy.mathpix_client import MathpixClient
+from mpxpy.webhooks import verify_signature, WebhookConfig
+from mpxpy.errors import ValidationError, FilesApiError
+
+
+SECRET = "whsec_test_secret"
+
+
+def _sign(body: bytes, secret: str = SECRET, timestamp: Optional[int] = None) -> str:
+    """Build a Mathpix-Signature header the same way the server does."""
+    t = int(time.time()) if timestamp is None else timestamp
+    message = f"{t}.".encode("utf-8") + body
+    signature = hmac.new(secret.encode("utf-8"), message, hashlib.sha256).hexdigest()
+    return f"t={t},v1={signature}"
+
+
+class FakeResponse:
+    def __init__(self, status_code: int = 200, json_body: Optional[Dict[str, Any]] = None) -> None:
+        self.status_code = status_code
+        self._json_body = json_body
+
+    @property
+    def ok(self) -> bool:
+        return self.status_code < 400
+
+    def json(self) -> Dict[str, Any]:
+        return self._json_body or {}
+
+
+@pytest.fixture
+def client() -> MathpixClient:
+    return MathpixClient(app_id="test-app", app_key="test-key")
+
+
+# verify_signature
+
+def test_verify_signature_valid_bytes_and_str() -> None:
+    body = b'{"event":"job.completed","job_id":"job-1"}'
+    header = _sign(body)
+    assert verify_signature(header, body, SECRET) is True
+    # A str body must encode identically to the bytes body
+    assert verify_signature(header, body.decode("utf-8"), SECRET) is True
+
+
+def test_verify_signature_rejects_tampered_body() -> None:
+    body = b'{"event":"job.completed"}'
+    header = _sign(body)
+    assert verify_signature(header, b'{"event":"job.failed"}', SECRET) is False
+
+
+def test_verify_signature_rejects_wrong_secret() -> None:
+    body = b'payload'
+    header = _sign(body)
+    assert verify_signature(header, body, "whsec_wrong") is False
+
+
+def test_verify_signature_rejects_stale_timestamp() -> None:
+    body = b'payload'
+    stale = int(time.time()) - 10_000
+    header = _sign(body, timestamp=stale)
+    assert verify_signature(header, body, SECRET) is False
+    # Widening the tolerance past the age accepts it again
+    assert verify_signature(header, body, SECRET, tolerance_seconds=20_000) is True
+
+
+def test_verify_signature_rejects_malformed_and_missing_fields() -> None:
+    body = b'payload'
+    assert verify_signature("not-a-signature-header", body, SECRET) is False
+    assert verify_signature("", body, SECRET) is False
+    # Present timestamp but missing v1
+    assert verify_signature(f"t={int(time.time())}", body, SECRET) is False
+
+
+# webhook_config_get / set / test
+
+def test_webhook_config_get_returns_config(client: MathpixClient) -> None:
+    config_body = {
+        "signing_secret": "whsec_abc",
+        "default_callback_url": "https://example.com/hook",
+        "default_callback_headers": {"X-Token": "t"},
+        "default_callback_events": ["job.completed"],
+    }
+    with patch("mpxpy.mathpix_client.get") as mock_get:
+        mock_get.return_value = FakeResponse(json_body=config_body)
+        config = client.webhook_config_get()
+    assert isinstance(config, WebhookConfig)
+    assert config.signing_secret == "whsec_abc"
+    assert config.default_callback_url == "https://example.com/hook"
+    assert config.default_callback_headers == {"X-Token": "t"}
+    assert config.default_callback_events == ["job.completed"]
+    args, _ = mock_get.call_args
+    assert args[0].endswith("/files/v1/webhook-config")
+
+
+def test_webhook_config_set_sends_only_provided_fields(client: MathpixClient) -> None:
+    with patch("mpxpy.mathpix_client.put") as mock_put:
+        mock_put.return_value = FakeResponse(json_body={"signing_secret": "whsec_abc"})
+        config = client.webhook_config_set(default_callback_url="https://example.com/hook")
+    assert isinstance(config, WebhookConfig)
+    args, kwargs = mock_put.call_args
+    assert args[0].endswith("/files/v1/webhook-config")
+    assert kwargs["json"] == {"default_callback_url": "https://example.com/hook"}
+
+
+def test_webhook_config_set_rejects_empty_events(client: MathpixClient) -> None:
+    with pytest.raises(ValidationError):
+        client.webhook_config_set(default_callback_events=[])
+
+
+def test_webhook_config_test_returns_probe_without_raising(client: MathpixClient) -> None:
+    probe = {"status": "failed", "response_code": 500, "detail": "endpoint returned 500"}
+    with patch("mpxpy.mathpix_client.post") as mock_post:
+        mock_post.return_value = FakeResponse(json_body=probe)
+        result = client.webhook_config_test()
+    assert result == probe
+    args, _ = mock_post.call_args
+    assert args[0].endswith("/files/v1/webhook-config/test")
+
+
+# file_job_finalize
+
+def test_file_job_finalize_returns_map(client: MathpixClient) -> None:
+    finalize_body = {"job_id": "job-1", "finalized_at": "2026-08-18T00:00:00Z", "message": "finalized"}
+    with patch("mpxpy.mathpix_client.post") as mock_post:
+        mock_post.return_value = FakeResponse(json_body=finalize_body)
+        result = client.file_job_finalize("job-1")
+    assert result == finalize_body
+    args, _ = mock_post.call_args
+    assert args[0].endswith("/files/v1/jobs/job-1/finalize")
+
+
+def test_file_job_finalize_unknown_id_raises(client: MathpixClient) -> None:
+    with patch("mpxpy.mathpix_client.post") as mock_post:
+        mock_post.return_value = FakeResponse(status_code=404, json_body={"error": "not_found"})
+        with pytest.raises(FilesApiError) as exc_info:
+            client.file_job_finalize("job-missing")
+    assert exc_info.value.error_id == "not_found"

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -12,7 +12,7 @@ import pytest
 from mpxpy.mathpix_client import MathpixClient
 from mpxpy.file_job import FileJob
 from mpxpy.webhooks import verify_signature, WebhookConfig
-from mpxpy.errors import FilesApiError
+from mpxpy.errors import ValidationError, FilesApiError
 
 
 SECRET = "whsec_test_secret"
@@ -113,6 +113,63 @@ def test_webhook_config_get_returns_signing_secret(client: MathpixClient) -> Non
     assert config.signing_secret == "whsec_abc"
     args, _ = mock_get.call_args
     assert args[0].endswith("/files/v1/webhook-config")
+
+
+# webhook_config_test
+
+def test_webhook_config_test_returns_probe_body(client: MathpixClient) -> None:
+    probe_body = {"status": "delivered", "response_code": 200, "detail": None}
+    with patch("mpxpy.mathpix_client.post") as mock_post:
+        mock_post.return_value = FakeResponse(json_body=probe_body)
+        outcome = client.webhook_config_test(
+            callback_url="https://example.com/hook",
+            callback_headers={"Authorization": "Bearer token"},
+        )
+    assert outcome == probe_body
+    args, kwargs = mock_post.call_args
+    assert args[0].endswith("/files/v1/webhook-config/test")
+    assert kwargs["json"] == {
+        "callback_url": "https://example.com/hook",
+        "callback_headers": {"Authorization": "Bearer token"},
+    }
+
+
+def test_webhook_config_test_omits_absent_headers(client: MathpixClient) -> None:
+    with patch("mpxpy.mathpix_client.post") as mock_post:
+        mock_post.return_value = FakeResponse(json_body={"status": "delivered", "response_code": 200, "detail": None})
+        client.webhook_config_test(callback_url="https://example.com/hook")
+    _, kwargs = mock_post.call_args
+    assert kwargs["json"] == {"callback_url": "https://example.com/hook"}
+
+
+def test_webhook_config_test_failed_probe_does_not_raise(client: MathpixClient) -> None:
+    # An endpoint that refuses the test is reported, not raised: the call itself
+    # succeeded and its body describes what the endpoint did.
+    probe_body = {"status": "failed", "response_code": None, "detail": "no response was received: Connection refused"}
+    with patch("mpxpy.mathpix_client.post") as mock_post:
+        mock_post.return_value = FakeResponse(json_body=probe_body)
+        outcome = client.webhook_config_test(callback_url="https://example.com/hook")
+    assert outcome == probe_body
+
+
+def test_webhook_config_test_rejected_url_raises(client: MathpixClient) -> None:
+    # The API's standalone error envelope, as the endpoint returns it for a
+    # callback_url it refuses.
+    error_body = {
+        "error": "bad_request",
+        "error_info": {"id": "bad_request", "message": "callback_url: callback_url must be https"},
+    }
+    with patch("mpxpy.mathpix_client.post") as mock_post:
+        mock_post.return_value = FakeResponse(status_code=400, json_body=error_body)
+        with pytest.raises(FilesApiError) as exc_info:
+            client.webhook_config_test(callback_url="http://example.com/hook")
+    assert exc_info.value.error_id == "bad_request"
+    assert exc_info.value.http_status == 400
+
+
+def test_webhook_config_test_requires_callback_url(client: MathpixClient) -> None:
+    with pytest.raises(ValidationError):
+        client.webhook_config_test(callback_url="")
 
 
 # FileJob.finalize

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, Optional
 from unittest.mock import patch
 import pytest
 from mpxpy.mathpix_client import MathpixClient
+from mpxpy.file_job import FileJob
 from mpxpy.webhooks import verify_signature, WebhookConfig
 from mpxpy.errors import ValidationError, FilesApiError
 
@@ -85,6 +86,8 @@ def test_verify_signature_rejects_malformed_and_missing_fields() -> None:
 # webhook_config_get / set / test
 
 def test_webhook_config_get_returns_config(client: MathpixClient) -> None:
+    # The response carries the default_callback_* wire keys; WebhookConfig
+    # exposes them under the bare callback_* names.
     config_body = {
         "signing_secret": "whsec_abc",
         "default_callback_url": "https://example.com/hook",
@@ -96,26 +99,42 @@ def test_webhook_config_get_returns_config(client: MathpixClient) -> None:
         config = client.webhook_config_get()
     assert isinstance(config, WebhookConfig)
     assert config.signing_secret == "whsec_abc"
-    assert config.default_callback_url == "https://example.com/hook"
-    assert config.default_callback_headers == {"X-Token": "t"}
-    assert config.default_callback_events == ["job.completed"]
+    assert config.callback_url == "https://example.com/hook"
+    assert config.callback_headers == {"X-Token": "t"}
+    assert config.callback_events == ["job.completed"]
     args, _ = mock_get.call_args
     assert args[0].endswith("/files/v1/webhook-config")
 
 
-def test_webhook_config_set_sends_only_provided_fields(client: MathpixClient) -> None:
-    with patch("mpxpy.mathpix_client.put") as mock_put:
-        mock_put.return_value = FakeResponse(json_body={"signing_secret": "whsec_abc"})
-        config = client.webhook_config_set(default_callback_url="https://example.com/hook")
+def test_webhook_config_set_preserves_unspecified_fields(client: MathpixClient) -> None:
+    # Read-modify-write: setting only callback_url must preserve the existing headers
+    # and events (the API's PUT is full-replacement, so the SDK reads then merges).
+    # The bare callback_* params map onto the default_callback_* wire keys.
+    current = {
+        "signing_secret": "whsec_abc",
+        "default_callback_url": "https://old.example.com/hook",
+        "default_callback_headers": {"Authorization": "Bearer keep"},
+        "default_callback_events": ["file.completed"],
+    }
+    with patch("mpxpy.mathpix_client.get") as mock_get, \
+            patch("mpxpy.mathpix_client.put") as mock_put:
+        mock_get.return_value = FakeResponse(json_body=current)
+        mock_put.return_value = FakeResponse(json_body={**current, "default_callback_url": "https://new.example.com/hook"})
+        config = client.webhook_config_set(callback_url="https://new.example.com/hook")
     assert isinstance(config, WebhookConfig)
+    assert mock_get.called  # read-modify-write read the current config first
     args, kwargs = mock_put.call_args
     assert args[0].endswith("/files/v1/webhook-config")
-    assert kwargs["json"] == {"default_callback_url": "https://example.com/hook"}
+    assert kwargs["json"] == {
+        "default_callback_url": "https://new.example.com/hook",
+        "default_callback_headers": {"Authorization": "Bearer keep"},
+        "default_callback_events": ["file.completed"],
+    }
 
 
 def test_webhook_config_set_rejects_empty_events(client: MathpixClient) -> None:
     with pytest.raises(ValidationError):
-        client.webhook_config_set(default_callback_events=[])
+        client.webhook_config_set(callback_events=[])
 
 
 def test_webhook_config_test_returns_probe_without_raising(client: MathpixClient) -> None:
@@ -128,21 +147,23 @@ def test_webhook_config_test_returns_probe_without_raising(client: MathpixClient
     assert args[0].endswith("/files/v1/webhook-config/test")
 
 
-# file_job_finalize
+# FileJob.finalize
 
-def test_file_job_finalize_returns_map(client: MathpixClient) -> None:
+def test_filejob_finalize_returns_map(client: MathpixClient) -> None:
     finalize_body = {"job_id": "job-1", "finalized_at": "2026-08-18T00:00:00Z", "message": "finalized"}
-    with patch("mpxpy.mathpix_client.post") as mock_post:
+    job = FileJob(auth=client.auth, job_id="job-1")
+    with patch("mpxpy.file_job.post") as mock_post:
         mock_post.return_value = FakeResponse(json_body=finalize_body)
-        result = client.file_job_finalize("job-1")
+        result = job.finalize()
     assert result == finalize_body
     args, _ = mock_post.call_args
     assert args[0].endswith("/files/v1/jobs/job-1/finalize")
 
 
-def test_file_job_finalize_unknown_id_raises(client: MathpixClient) -> None:
-    with patch("mpxpy.mathpix_client.post") as mock_post:
+def test_filejob_finalize_unknown_id_raises(client: MathpixClient) -> None:
+    job = FileJob(auth=client.auth, job_id="job-missing")
+    with patch("mpxpy.file_job.post") as mock_post:
         mock_post.return_value = FakeResponse(status_code=404, json_body={"error": "not_found"})
         with pytest.raises(FilesApiError) as exc_info:
-            client.file_job_finalize("job-missing")
+            job.finalize()
     assert exc_info.value.error_id == "not_found"

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -97,8 +97,8 @@ def test_verify_signature_accepts_any_of_multiple_v1() -> None:
     message = f"{t}.".encode("utf-8") + body
     good = hmac.new(SECRET.encode("utf-8"), message, hashlib.sha256).hexdigest()
     wrong = hmac.new(b"whsec_other", message, hashlib.sha256).hexdigest()
-    # During a secret rotation the header carries a v1 for each secret; a match
-    # on any one of them verifies.
+    # A header carries a single v1 today; verify_signature also accepts multiple
+    # v1 values (forward-compat) and passes if any one matches.
     assert verify_signature(f"t={t},v1={wrong},v1={good}", body, SECRET) is True
     assert verify_signature(f"t={t},v1={wrong},v1={wrong}", body, SECRET) is False
 

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -83,6 +83,26 @@ def test_verify_signature_rejects_malformed_and_missing_fields() -> None:
     assert verify_signature(f"t={int(time.time())}", body, SECRET) is False
 
 
+def test_verify_signature_rejects_empty_secret() -> None:
+    body = b'payload'
+    # A header that IS a valid HMAC keyed with the empty secret must still be
+    # rejected: an empty secret fails closed rather than keying the HMAC with it.
+    header = _sign(body, secret="")
+    assert verify_signature(header, body, "") is False
+
+
+def test_verify_signature_accepts_any_of_multiple_v1() -> None:
+    body = b'{"event":"job.completed"}'
+    t = int(time.time())
+    message = f"{t}.".encode("utf-8") + body
+    good = hmac.new(SECRET.encode("utf-8"), message, hashlib.sha256).hexdigest()
+    wrong = hmac.new(b"whsec_other", message, hashlib.sha256).hexdigest()
+    # During a secret rotation the header carries a v1 for each secret; a match
+    # on any one of them verifies.
+    assert verify_signature(f"t={t},v1={wrong},v1={good}", body, SECRET) is True
+    assert verify_signature(f"t={t},v1={wrong},v1={wrong}", body, SECRET) is False
+
+
 # webhook_config_get / set / test
 
 def test_webhook_config_get_returns_config(client: MathpixClient) -> None:


### PR DESCRIPTION
Client support for Files API webhooks: per-request callbacks, signature verification, the signing-secret fetch, and job finalization.

## What's here

**Per-request callbacks** — `callback_url` / `callback_headers` / `callback_events` on `file_new` (`/files/v1`, `/files/v1/uri`), `pdf_new` (`/v3/pdf`), and `file_job_new` (`/files/v1/jobs`). You set the destination, any auth headers, and which events you want per submission — there is no account-level default. Applied through a shared `_apply_callback_options` helper so every submit path serializes them identically.

**Signature verification** — `mpxpy.webhooks.verify_signature(signature_header, body, secret, tolerance_seconds=300) -> bool`. Pure and stateless: recomputes HMAC-SHA256 over `"{t}.{raw_body}"` with the secret as the UTF-8 key, constant-time compares it to the header's `v1` value(s), and rejects a timestamp outside the replay window (300s default). Fails closed on any invalid or missing input, including an empty secret; never raises. Accepts a header carrying more than one `v1` value, so it keeps working if signature rotation is ever added. Exported from `mpxpy`.

**Signing secret** — `client.webhook_config_get() -> WebhookConfig` performs `GET /files/v1/webhook-config` and returns a `WebhookConfig` exposing `.signing_secret`. The secret is per app key (each app key has its own), minted on the first call.

**Batch completion** — `FileJob.finalize()` closes a job to new submissions so its single `job.completed` webhook can fire, once every file in it has finished.

**Cleanup** — removed the never-enabled legacy `webhook_url` / `mathpix_webhook_secret` / `webhook_payload` / `webhook_enabled_events` params from `pdf_new` / `Pdf` (they raised `NotImplementedError` against the production API).

## Events

`file.completed` and `file.error` for a single document (success and failure); `job.completed` for a finalized batch (delivered once). With `callback_events` omitted, a single-document submission defaults to `file.completed` + `file.error`, and a batch defaults to `job.completed` only; the selection is resolved server-side.

## Notes

- No account-level configuration: a notification's destination, headers, and event selection all come from the submission.
- `extra_options` cannot override the callback params on any submit method.
- Secret rotation is not included (no server endpoint yet); `verify_signature` already tolerates multiple `v1` values so no client change is needed if it ships.

## Tests

Unit suite green, including `verify_signature` against a vector built with the exact server scheme (valid bytes/str, tampered body, wrong secret, empty secret, stale timestamp, malformed header, and multiple `v1`), `webhook_config_get` and `FileJob.finalize` with the request handler mocked, and callback serialization on the `file_new` / `pdf_new` / `file_job_new` submit paths.

Version bumped to 0.0.22; changelog updated.

Triggered by user request: add Files API webhooks support to the mpxpy client for the webhooks launch.